### PR TITLE
Rotary redesign

### DIFF
--- a/patient/buzzer.py
+++ b/patient/buzzer.py
@@ -28,9 +28,7 @@ class Buzzer:
         assert self.pi is not None, 'Must use "with" to use'
 
         with self._lock:
-            self.pi.set_PWM_dutycycle(self.PIN, 0)
-
-    # CGT            self.pi.set_PWM_dutycycle(self.PIN, volume)
+            self.pi.set_PWM_dutycycle(self.PIN, volume)
 
     def _thread_pattern(
         self, volume: int, time_on: float, time_off: float, timer: Optional[float]

--- a/patient/rotary.py
+++ b/patient/rotary.py
@@ -3,6 +3,7 @@ import pigpio
 from patient.rotary_live import LiveRotary
 from processor.setting import Setting
 import enum
+import threading
 from typing import Callable, Dict, Any, Optional, TypeVar
 
 pinA = 17  # terminal A
@@ -143,5 +144,18 @@ class Rotary(LiveRotary):
         return super().__exit__(*exc)
 
 
-# from processor.settings import get_live_settings
-# with Rotary(get_live_settings()) as rotary:
+if __name__ == "__main__":
+
+    class SimpleRotary(Rotary):
+        def turn(self, dir: Dir) -> None:
+            print("Turned", dir)
+
+        def pushed_turn(self, dir: Dir) -> None:
+            print("Pushed turn", dir)
+
+        def push(self) -> None:
+            print("Pushed")
+
+    with SimpleRotary({}):
+        forever = threading.Event()
+        forever.wait()

--- a/patient/rotary_lcd.py
+++ b/patient/rotary_lcd.py
@@ -8,10 +8,11 @@ from patient.rotary import Rotary, Dir
 from patient.lcd import LCD
 from patient.backlight import Backlight
 from patient.buzzer import Buzzer
+from processor.config import config as _config
+
 import pigpio
 from typing import Dict
 import enum
-
 import time
 
 
@@ -29,6 +30,7 @@ class RotaryLCD(Rotary):
         self.backlight = Backlight(pi=pi)
         self.buzzer = Buzzer(pi=pi)
         self.alarm_level: AlarmLevel = AlarmLevel.OFF
+        self.buzzer_volume: int = _config["patient"]["buzzer-volume"].get(int)
 
     def external_update(self) -> None:
         self.upper_display()
@@ -96,7 +98,7 @@ class RotaryLCD(Rotary):
     def alert(self) -> None:
         if self.alarms and self.alarm_level == AlarmLevel.OFF:
             self.backlight.red()
-            self.buzzer.buzz(200)
+            self.buzzer.buzz(self.buzzer_volume)
             self.alarm_level = AlarmLevel.LOUD
         elif not self.alarms:
             self.backlight.white()

--- a/povm.yml
+++ b/povm.yml
@@ -13,7 +13,7 @@ rotary:
     default: 50
     min: -150
     max: 150
-    incr: 5
+    incr: 1
     unit: L/min
 
   Avg Flow Max:
@@ -22,7 +22,7 @@ rotary:
     default: 100
     min: -150
     max: 150
-    incr: 5
+    incr: 1
     unit: L/min
 
   Avg Pressure Min:
@@ -49,7 +49,7 @@ rotary:
     default: 40
     min: 5
     max: 180
-    incr: 5
+    incr: 1
     unit: 1/min
 
   Stale Data Timeout:
@@ -59,6 +59,6 @@ rotary:
     default: 10
     min: 0
     max: 60
-    incr: 2
+    incr: 1
     unit: sec
     zero: "OFF"

--- a/povm.yml
+++ b/povm.yml
@@ -6,6 +6,9 @@ device:
     offset: 0.0
     scale: 0.7198
 
+patient:
+  buzzer-volume: 0
+
 rotary:
   Avg Flow Min:
     type: Incr

--- a/povm.yml
+++ b/povm.yml
@@ -6,9 +6,6 @@ device:
     offset: 0.0
     scale: 0.7198
 
-patient:
-  buzzer-volume: 0
-
 rotary:
   Avg Flow Min:
     type: Incr

--- a/processor/config_default.yaml
+++ b/processor/config_default.yaml
@@ -31,6 +31,7 @@ rotary-live:
     type: Current
     default: 3
     items: [1, 3, 5, 10, 20, 30]
+    rate: 3
 
 rotary:
   AvgWindow:
@@ -40,6 +41,7 @@ rotary:
     default: 3
     items: [1, 3, 5, 10, 20, 30]
     unit: s
+    rate: 3
 
   Sensor ID:
     type: Incr

--- a/processor/config_default.yaml
+++ b/processor/config_default.yaml
@@ -15,6 +15,9 @@ global:
   window-size: 1500 # 30 seconds @ 50 hertz
   broadcast-ifaces: [en0, eth0, wlan0]
 
+patient:
+  buzzer-volume: 0
+
 rotary-live:
   Log Filename:
     type: Filename

--- a/processor/display_settings.py
+++ b/processor/display_settings.py
@@ -32,13 +32,15 @@ class FilenameSetting(DisplaySetting):
 
 
 class CurrentSetting(SelectionSetting):
-    def __init__(self, default: int, listing: Sequence[int], *, name: str):
+    def __init__(
+        self, default: int, listing: Sequence[int], *, name: str, rate: int = 2
+    ):
         string_listing = [f"{s}s" for s in listing]
 
         self._F: Optional[List[float]] = None
         self._P: Optional[List[float]] = None
 
-        super().__init__(default, string_listing, name=name)
+        super().__init__(default, string_listing, name=name, rate=rate)
 
     def from_processor(self, F: List[float], P: List[float]):
         self._F = F
@@ -70,8 +72,10 @@ class CurrentSetting(SelectionSetting):
 
 
 class ResetSetting(SelectionSetting):
-    def __init__(self, name: str):
-        super().__init__(0, [f"[{x*'x':8}]" for x in range(9)], name=name)
+    def __init__(self, name: str, rate: int = 1):
+        super().__init__(
+            0, [f"[{x*'x':8}]" for x in range(9)] + ["RESET"], name=name, rate=rate
+        )
 
     def active(self) -> None:
         self._value = 0

--- a/processor/settings.py
+++ b/processor/settings.py
@@ -19,6 +19,7 @@ def get_setting(c: ConfigView) -> Setting:
             incr=c["incr"].as_number(),
             name=c["name"].get(),
             unit=c["unit"].get() if "unit" in c else None,
+            rate=c["rate"].get(int) if "rate" in c else 1,
             zero=c["zero"].get() if "zero" in c else None,
             lcd_name=c["lcd_name"].get() if "lcd_name" in c else None,
         )
@@ -29,16 +30,20 @@ def get_setting(c: ConfigView) -> Setting:
             name=c["name"].get(),
             unit=c["unit"].get() if "unit" in c else None,
             zero=c["zero"].get() if "zero" in c else None,
+            rate=c["rate"].get(int) if "rate" in c else 2,
             lcd_name=c["lcd_name"].get() if "lcd_name" in c else None,
         )
     elif type_name == "Current":
         return CurrentSetting(
             default=c["default"].get(int),
             listing=[v.as_number() for v in c["items"]],
+            rate=c["rate"].get(int) if "rate" in c else 2,
             name="Current:",
         )
     elif type_name == "Reset":
-        return ResetSetting(name=c["name"].get(),)
+        return ResetSetting(
+            name=c["name"].get(), rate=c["rate"].get(int) if "rate" in c else 1,
+        )
     elif type_name == "Filename":
         return FilenameSetting("Log filename")
     else:


### PR DESCRIPTION
I've nailed the rotary interaction. :)

Normal glitch filters do not work properly on a rotary, because it has state. So if you filter a “glitch” that changed state, then the next time, you think you are in the wrong state and move backwards, causing the odd behaviors we were seeing.

We now use different rates for different settings, so incremental settings are smoother and choice list settings are very easy to select.