### PR TITLE
Adding names to display

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,22 @@ Click on terminal icon and execute:
 ```bash
 git clone https://github.com/Princeton-Penn-Vents/princeton-penn-flowmeter
 # if a username is requested, then a typo has been made in the name, try again carefully
+
 cd princeton-penn-flowmeter
 sudo apt update
 sudo apt upgrade
+
 sudo apt install python3-pyqt5 python3-zmq # Required on the base system, included in NOOBs
 sudo apt install python3-scipy
-sudo apt install vim htop                  # For development, skip for production
-sudo python3 -m pip install pyqtgraph pyzmq confuse zeroconf getmac
-sudo python3 -m pip install black pytest mypy   # Useful for development, skip for production
+sudo python3 -m pip install pyqtgraph pyzmq confuse zeroconf
+sudo pytohn3 -m pip install "setuptools>=44" getmac setuptools_scm[toml]
+```
+
+For development, these quality-of-life additions help:
+
+```bash
+sudo apt install vim htop
+python3 -m pip install black pytest mypy
 ```
 
 <details><summary>Networking for the nurse box: (click to expand)</summary>

--- a/environment.yml
+++ b/environment.yml
@@ -14,3 +14,4 @@ dependencies:
   - scipy
   - confuse
   - zeroconf
+  - markdown

--- a/nurse/connection_dialog.py
+++ b/nurse/connection_dialog.py
@@ -35,7 +35,7 @@ class DetectedTab(QtWidgets.QWidget):
         self.detected = QtWidgets.QComboBox()
         layout.addRow("Detected:", self.detected)
 
-        self.detected.setMinimumWidth(180)
+        self.detected.setMinimumWidth(290)
 
 
 class TabbedConnection(QtWidgets.QTabWidget):

--- a/nurse/connection_dialog.py
+++ b/nurse/connection_dialog.py
@@ -75,7 +75,7 @@ class ConnectionDialog(QtWidgets.QDialog):
 
         layout.addWidget(buttons)
 
-    def exec(self):
+    def exec(self) -> int:
         self.setWindowTitle(f"Patient box {self.i} connection")
 
         parsed = urlparse(self.address)

--- a/nurse/drilldown.py
+++ b/nurse/drilldown.py
@@ -472,8 +472,11 @@ class PatientDrilldownWidget(QtWidgets.QFrame):
             )
         else:
             cumulative = "Disconnected"
+        if not cumulative:
+            cumulative = "No computed values yet"
 
         box = QtWidgets.QMessageBox()
+        box.setWindowTitle("Computed values")
         box.setTextFormat(Qt.RichText)
         box.setText(cumulative)
         box.exec()
@@ -489,6 +492,7 @@ class PatientDrilldownWidget(QtWidgets.QFrame):
             active_alarms = "No alarms currently."
 
         box = QtWidgets.QMessageBox()
+        box.setWindowTitle("Active alarms")
         box.setTextFormat(Qt.RichText)
         box.setText(active_alarms)
         box.exec()
@@ -500,6 +504,7 @@ class PatientDrilldownWidget(QtWidgets.QFrame):
         )
 
         box = QtWidgets.QMessageBox()
+        box.setWindowTitle("Currently set alarm limits")
         box.setTextFormat(Qt.RichText)
         box.setText(rotary_text)
         box.exec()

--- a/nurse/drilldown.py
+++ b/nurse/drilldown.py
@@ -205,6 +205,7 @@ class PatientTitle(QtWidgets.QWidget):
         self.name_edit.disconnect()
         self.name_lbl.setText(number)
         self.name_edit.setText(mirror.text())
+        self.name_edit.setPlaceholderText(mirror.placeholderText())
         self.name_edit.textChanged.connect(mirror.setText)
 
     @Slot()
@@ -428,7 +429,9 @@ class PatientDrilldownWidget(QtWidgets.QFrame):
         box.exec()
 
     def update_addr(self):
-        text = f"Box name: {self.gen.record.box_name}  Sensor ID: {self.gen.record.sid}"
+        text = (
+            f"Box name: {self.gen.record.box_name}  Sensor ID: {self.gen.record.sid:X}"
+        )
         if self.title_warning.text() != text:
             self.title_warning.setText(text)
 

--- a/nurse/drilldown.py
+++ b/nurse/drilldown.py
@@ -19,7 +19,7 @@ from nurse.qt import (
 
 from nurse.common import GraphInfo
 from nurse.header import DrilldownHeaderWidget
-from nurse.dragdrop import DragDropGridMixin
+from nurse.gen_record_gui import GenRecordGUI
 from processor.generator import Status, Generator
 from nurse.generator_dialog import GeneratorDialog
 
@@ -280,15 +280,19 @@ class AlarmBox(QtWidgets.QPushButton):
             super().__init__("\n".join(gen.record.box_name.split()))
             self.setProperty("nurse_id", "auto")
         self.gen = gen
+        record: GenRecordGUI
+        record = self.gen.record  # type: ignore
+        record.master_signal.title_changed.connect(self.update_gen)
         self.active = False
         self.i = i
 
+    @Slot()
     def update_gen(self):
         if self.gen.record.title:
-            super().__init__(self.gen.record.title)
+            self.setText(self.gen.record.title)
             self.auto = False
         else:
-            super().__init__("\n".join(self.gen.record.box_name.split()))
+            self.setText("\n".join(self.gen.record.box_name.split()))
             self.auto = True
 
     @property

--- a/nurse/drilldown.py
+++ b/nurse/drilldown.py
@@ -209,8 +209,7 @@ class PatientTitle(QtWidgets.QWidget):
 
     @Slot()
     def click_number(self):
-        print("Not implemented")
-        dialog = GeneratorDialog()
+        dialog = GeneratorDialog(self.parent().gen)
         if dialog.exec():
             pass
 

--- a/nurse/drilldown.py
+++ b/nurse/drilldown.py
@@ -190,7 +190,7 @@ class PatientTitle(QtWidgets.QWidget):
         super().__init__()
         layout = HBoxLayout(self)
 
-        self.name_lbl = QtWidgets.QPushButton("X")
+        self.name_lbl = QtWidgets.QPushButton("i")
         self.name_lbl.clicked.connect(self.click_number)
         layout.addWidget(self.name_lbl)
 
@@ -201,9 +201,8 @@ class PatientTitle(QtWidgets.QWidget):
         self.name_lbl.style().unpolish(self.name_lbl)
         self.name_edit.style().polish(self.name_edit)
 
-    def activate(self, number: str, mirror: QtWidgets.QLineEdit):
+    def activate(self, mirror: QtWidgets.QLineEdit):
         self.name_edit.disconnect()
-        self.name_lbl.setText(number)
         self.name_edit.setText(mirror.text())
         self.name_edit.setPlaceholderText(mirror.placeholderText())
         self.name_edit.textChanged.connect(mirror.setText)
@@ -234,16 +233,16 @@ class DrilldownWidget(QtWidgets.QWidget):
         side_layout = VBoxLayout()
         columns_layout.addLayout(side_layout)
 
-        self.grid_layout = GridLayout()
-        side_layout.addLayout(self.grid_layout)
+        self.alarms_layout = VBoxLayout()
+        side_layout.addLayout(self.alarms_layout)
         side_layout.addStretch()
 
         self.alarm_boxes: List[AlarmBox] = []
 
-    def add_alarm_box(self, gen: Generator, i: int):
+    def add_alarm_box(self, gen: Generator):
         alarm_box = AlarmBox(gen)
         self.alarm_boxes.append(alarm_box)
-        self.grid_layout.addWidget(alarm_box, *divmod(i, 2))
+        self.alarms_layout.addWidget(alarm_box)
         alarm_box.clicked.connect(self.click_alarm)
 
     @Slot()
@@ -264,7 +263,7 @@ class DrilldownWidget(QtWidgets.QWidget):
         name_btn = main_stack.graphs[i].title_widget.name_btn
         name_edit = main_stack.graphs[i].title_widget.name_edit
 
-        self.patient.title.activate(name_btn.text(), name_edit)
+        self.patient.title.activate(name_edit)
 
         self.patient.gen = main_stack.graphs[i].gen
         self.patient.update_plot(True)
@@ -274,16 +273,11 @@ class DrilldownWidget(QtWidgets.QWidget):
         self.patient.qTimer.stop()
 
 
-class AlarmBox(QtWidgets.QPushButton, DragDropGridMixin):
+class AlarmBox(QtWidgets.QPushButton):
     def __init__(self, gen: Generator):
-        super().__init__(gen.record.nurse_id)
+        super().__init__("\n".join(gen.record.box_name.split()))
         self.gen = gen
         self.active = False
-
-    def mouseReleaseEvent(self, event: QtGui.QMouseEvent) -> None:
-        if event.button() == Qt.LeftButton:
-            if self._start_pos is not None:
-                self.clicked.emit()
 
     @property
     def status(self) -> Status:
@@ -377,6 +371,9 @@ class PatientDrilldownWidget(QtWidgets.QFrame):
         buttons_layout.addWidget(all_alarms, 1)
         buttons_layout.addWidget(all_cumulative, 1)
         buttons_layout.addWidget(all_rotary, 1)
+
+        lim_help = QtWidgets.QLabel("All alarm limits are set on the device")
+        displays_layout.addWidget(lim_help)
 
         displays_layout.addStretch()
 

--- a/nurse/drilldown.py
+++ b/nurse/drilldown.py
@@ -195,6 +195,7 @@ class PatientTitle(QtWidgets.QWidget):
         layout.addWidget(self.name_lbl)
 
         self.name_edit = QtWidgets.QLineEdit()
+        self.name_edit.setPlaceholderText("Please add title")
         layout.addWidget(self.name_edit)
 
         self.name_edit.editingFinished.connect(self.update_title)
@@ -209,7 +210,6 @@ class PatientTitle(QtWidgets.QWidget):
 
     def activate(self) -> None:
         self.name_edit.setText(self.record.title)
-        self.name_edit.setPlaceholderText(self.record.box_name)
         self.record.master_signal.title_changed.connect(self.external_update_title)
 
     def deactivate(self) -> None:
@@ -368,9 +368,21 @@ class PatientDrilldownWidget(QtWidgets.QFrame):
         self.title = PatientTitle()
         left_layout.addWidget(self.title)
 
-        self.title_warning = QtWidgets.QLabel("Box name: not yet known")
-        self.title_warning.setObjectName("TitleWarning")
-        left_layout.addWidget(self.title_warning, 0, Qt.AlignHCenter)
+        warning_layout = QtWidgets.QHBoxLayout()
+        left_layout.addLayout(warning_layout)
+
+        warning_layout.addStretch()
+
+        self.box_name = QtWidgets.QLabel("Box name: not yet known")
+        self.box_name.setObjectName("TitleWarning")
+        warning_layout.addWidget(self.box_name)
+
+        warning_layout.addStretch()
+
+        self.sensor_id = QtWidgets.QLabel("Sensor ID: not yet known")
+        warning_layout.addWidget(self.sensor_id)
+
+        warning_layout.addStretch()
 
         self.graphview = pg.GraphicsView(parent=self)
         graph_layout = pg.GraphicsLayout()
@@ -471,11 +483,13 @@ class PatientDrilldownWidget(QtWidgets.QFrame):
         box.exec()
 
     def update_addr(self):
-        text = (
-            f"Box name: {self.gen.record.box_name}  Sensor ID: {self.gen.record.sid:X}"
-        )
-        if self.title_warning.text() != text:
-            self.title_warning.setText(text)
+        text = rf'Box name: <span style="font-style:italic;font-size:16pt;font-weight:bold;color:floralwhite;">{self.gen.record.box_name}</span>'
+        if self.box_name.text() != text:
+            self.box_name.setText(text)
+
+        text = f"Sensor ID: {self.gen.record.sid:X}"
+        if self.sensor_id.text() != text:
+            self.sensor_id.setText(text)
 
     def set_plot(self, graph_layout, phase_layout):
         gis = GraphInfo()

--- a/nurse/drilldown.py
+++ b/nurse/drilldown.py
@@ -9,12 +9,12 @@ import numpy as np
 from nurse.qt import (
     QtCore,
     QtWidgets,
-    QtGui,
     Qt,
     Slot,
     HBoxLayout,
     VBoxLayout,
     GridLayout,
+    BoxName,
 )
 
 from nurse.common import GraphInfo
@@ -317,17 +317,14 @@ class DrilldownWidget(QtWidgets.QWidget):
 
 class AlarmBox(QtWidgets.QPushButton):
     def __init__(self, gen: Generator, i: int):
-        if gen.record.title:
-            super().__init__(gen.record.title)
-        else:
-            super().__init__("\n".join(gen.record.box_name.split()))
-            self.setProperty("nurse_id", "auto")
-        self.gen = gen
+        super().__init__()
+        self.gen: Generator = gen
         record: GenRecordGUI
         record = self.gen.record  # type: ignore
         record.master_signal.title_changed.connect(self.update_gen)
         self.active = False
         self.i = i
+        self.update_gen()
 
     @Slot()
     def update_gen(self):
@@ -335,7 +332,7 @@ class AlarmBox(QtWidgets.QPushButton):
             self.setText(self.gen.record.title)
             self.auto = False
         else:
-            self.setText("\n".join(self.gen.record.box_name.split()))
+            self.setText(self.gen.record.stacked_name)
             self.auto = True
 
     @property
@@ -388,8 +385,8 @@ class PatientDrilldownWidget(QtWidgets.QFrame):
 
         warning_layout.addStretch()
 
-        self.box_name = QtWidgets.QLabel("Box name: not yet known")
-        self.box_name.setObjectName("TitleWarning")
+        warning_layout.addWidget(QtWidgets.QLabel("Box name:"))
+        self.box_name = BoxName("<unknown>")
         warning_layout.addWidget(self.box_name)
 
         warning_layout.addStretch()
@@ -509,7 +506,7 @@ class PatientDrilldownWidget(QtWidgets.QFrame):
 
     @Slot()
     def external_update_boxname(self):
-        text = rf'Box name: <span style="font-style:italic;font-size:16pt;font-weight:bold;color:floralwhite;">{self.gen.record.box_name}</span>'
+        text = self.gen.record.box_name
         if self.box_name.text() != text:
             self.box_name.setText(text)
 

--- a/nurse/gen_record_gui.py
+++ b/nurse/gen_record_gui.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from processor.gen_record import GenRecord
+from nurse.qt import Signal, QtCore
+
+
+class RecordSignals(QtCore.QObject):
+    title_changed = Signal()
+
+
+@dataclass
+class GenRecordGUI(GenRecord):
+    master_signal: RecordSignals = field(default_factory=RecordSignals)
+
+    def title_changed(self) -> None:
+        self.master_signal.title_changed.emit()

--- a/nurse/gen_record_gui.py
+++ b/nurse/gen_record_gui.py
@@ -8,6 +8,8 @@ from nurse.qt import Signal, QtCore
 
 class RecordSignals(QtCore.QObject):
     title_changed = Signal()
+    mac_changed = Signal()
+    sid_changed = Signal()
 
 
 @dataclass
@@ -16,3 +18,9 @@ class GenRecordGUI(GenRecord):
 
     def title_changed(self) -> None:
         self.master_signal.title_changed.emit()
+
+    def mac_changed(self) -> None:
+        self.master_signal.mac_changed.emit()
+
+    def sid_changed(self) -> None:
+        self.master_signal.sid_changed.emit()

--- a/nurse/generator_dialog.py
+++ b/nurse/generator_dialog.py
@@ -1,4 +1,4 @@
-from nurse.qt import QtWidgets, Qt, Slot
+from nurse.qt import QtWidgets
 from processor.generator import Generator
 
 
@@ -8,16 +8,20 @@ class BasicTab(QtWidgets.QWidget):
 
         layout = QtWidgets.QVBoxLayout(self)
 
-        self.title = QtWidgets.QLineEdit()
-        self.title.setPlaceholderText(gen.record.box_name)
-        layout.addWidget(self.title)
+        layout.addWidget(
+            QtWidgets.QLabel(
+                "Please make sure a title is set to make box identification easier.\n"
+                "The first few characters will be shown in the drilldown alarm screen."
+            )
+        )
 
         form_layout = QtWidgets.QFormLayout()
         layout.addLayout(form_layout)
 
-        view_layout = QtWidgets.QFormLayout()
-        layout.addLayout(view_layout)
+        self.title = QtWidgets.QLineEdit()
+        self.title.setPlaceholderText("Please add title")
 
+        form_layout.addRow("Title:", self.title)
         form_layout.addRow("Box Name:", QtWidgets.QLabel(gen.record.box_name))
 
 

--- a/nurse/generator_dialog.py
+++ b/nurse/generator_dialog.py
@@ -42,6 +42,8 @@ class DetailsTab(QtWidgets.QWidget):
 class GeneratorDialog(QtWidgets.QDialog):
     def __init__(self, gen: Generator):
         super().__init__()
+        self.setWindowTitle(f"Info for {gen.record.box_name}")
+
         self.gen = gen
         layout = QtWidgets.QVBoxLayout(self)
 

--- a/nurse/generator_dialog.py
+++ b/nurse/generator_dialog.py
@@ -60,6 +60,4 @@ class GeneratorDialog(QtWidgets.QDialog):
         self.buttons.rejected.connect(self.reject)
 
     def exec(self) -> int:
-        res = super().exec()
-        print(f"Accepted: {res}")
-        return res
+        return super().exec()

--- a/nurse/generator_dialog.py
+++ b/nurse/generator_dialog.py
@@ -37,6 +37,7 @@ class DetailsTab(QtWidgets.QWidget):
 class GeneratorDialog(QtWidgets.QDialog):
     def __init__(self, gen: Generator):
         super().__init__()
+        self.gen = gen
         layout = QtWidgets.QVBoxLayout(self)
 
         self.basic = BasicTab(gen)
@@ -60,4 +61,7 @@ class GeneratorDialog(QtWidgets.QDialog):
         self.buttons.rejected.connect(self.reject)
 
     def exec(self) -> int:
-        return super().exec()
+        result = super().exec()
+        if result:
+            self.gen.record.title = self.basic.title.text()
+        return result

--- a/nurse/generator_dialog.py
+++ b/nurse/generator_dialog.py
@@ -31,7 +31,7 @@ class DetailsTab(QtWidgets.QWidget):
         layout = QtWidgets.QFormLayout(self)
 
         layout.addRow("MAC Addr:", QtWidgets.QLabel(gen.record.mac))
-        layout.addRow("Sensor:", QtWidgets.QLabel(str(gen.record.sid)))
+        layout.addRow("Sensor:", QtWidgets.QLabel(format(gen.record.sid, "X")))
         layout.addRow(
             "IP Address:", QtWidgets.QLabel(getattr(gen, "address", "Simulation"))
         )

--- a/nurse/generator_dialog.py
+++ b/nurse/generator_dialog.py
@@ -1,0 +1,9 @@
+from nurse.qt import QtWidgets, Qt, Slot
+
+
+class GeneratorDialog(QtWidgets.QDialog):
+    def __init__(self):
+        super().__init__()
+
+    def exec(self):
+        return super().exec()

--- a/nurse/generator_dialog.py
+++ b/nurse/generator_dialog.py
@@ -15,9 +15,6 @@ class BasicTab(QtWidgets.QWidget):
         form_layout = QtWidgets.QFormLayout()
         layout.addLayout(form_layout)
 
-        self.nid = QtWidgets.QLineEdit()
-        form_layout.addRow("Short ID:", self.nid)
-
         view_layout = QtWidgets.QFormLayout()
         layout.addLayout(view_layout)
 
@@ -52,8 +49,17 @@ class GeneratorDialog(QtWidgets.QDialog):
         self.buttons = QtWidgets.QDialogButtonBox()
         self.buttons.addButton(QtWidgets.QDialogButtonBox.Ok)
         self.buttons.addButton(QtWidgets.QDialogButtonBox.Cancel)
-        self.buttons.addButton("Disconnect", QtWidgets.QDialogButtonBox.DestructiveRole)
+        self.discon = self.buttons.addButton(
+            "Disconnect", QtWidgets.QDialogButtonBox.DestructiveRole
+        )
+        self.discon.setEnabled(False)
+        self.discon.setToolTip("You can only disconnect an unplugged sensor")
         layout.addWidget(self.buttons)
 
-    def exec(self):
-        return super().exec()
+        self.buttons.accepted.connect(self.accept)
+        self.buttons.rejected.connect(self.reject)
+
+    def exec(self) -> int:
+        res = super().exec()
+        print(f"Accepted: {res}")
+        return res

--- a/nurse/generator_dialog.py
+++ b/nurse/generator_dialog.py
@@ -5,5 +5,7 @@ class GeneratorDialog(QtWidgets.QDialog):
     def __init__(self):
         super().__init__()
 
+        layout = QtWidgets.QVBoxLayout(self)
+
     def exec(self):
         return super().exec()

--- a/nurse/generator_dialog.py
+++ b/nurse/generator_dialog.py
@@ -19,7 +19,8 @@ class BasicTab(QtWidgets.QWidget):
         layout.addLayout(form_layout)
 
         self.title = QtWidgets.QLineEdit()
-        self.title.setPlaceholderText("Please add title")
+        self.title.setPlaceholderText("Please enter title")
+        self.title.setText(gen.record.title)
 
         form_layout.addRow("Title:", self.title)
         form_layout.addRow("Box Name:", QtWidgets.QLabel(gen.record.box_name))

--- a/nurse/generator_dialog.py
+++ b/nurse/generator_dialog.py
@@ -1,11 +1,59 @@
 from nurse.qt import QtWidgets, Qt, Slot
+from processor.generator import Generator
 
 
-class GeneratorDialog(QtWidgets.QDialog):
-    def __init__(self):
+class BasicTab(QtWidgets.QWidget):
+    def __init__(self, gen: Generator):
         super().__init__()
 
         layout = QtWidgets.QVBoxLayout(self)
+
+        self.title = QtWidgets.QLineEdit()
+        self.title.setPlaceholderText(gen.record.box_name)
+        layout.addWidget(self.title)
+
+        form_layout = QtWidgets.QFormLayout()
+        layout.addLayout(form_layout)
+
+        self.nid = QtWidgets.QLineEdit()
+        form_layout.addRow("Short ID:", self.nid)
+
+        view_layout = QtWidgets.QFormLayout()
+        layout.addLayout(view_layout)
+
+        form_layout.addRow("Box Name:", QtWidgets.QLabel(gen.record.box_name))
+
+
+class DetailsTab(QtWidgets.QWidget):
+    def __init__(self, gen: Generator):
+        super().__init__()
+
+        layout = QtWidgets.QFormLayout(self)
+
+        layout.addRow("MAC Addr:", QtWidgets.QLabel(gen.record.mac))
+        layout.addRow("Sensor:", QtWidgets.QLabel(str(gen.record.sid)))
+        layout.addRow(
+            "IP Address:", QtWidgets.QLabel(getattr(gen, "address", "Simulation"))
+        )
+
+
+class GeneratorDialog(QtWidgets.QDialog):
+    def __init__(self, gen: Generator):
+        super().__init__()
+        layout = QtWidgets.QVBoxLayout(self)
+
+        self.basic = BasicTab(gen)
+        self.details = DetailsTab(gen)
+        self.selection = QtWidgets.QTabWidget()
+        self.selection.addTab(self.basic, "Basic")
+        self.selection.addTab(self.details, "Details")
+        layout.addWidget(self.selection)
+
+        self.buttons = QtWidgets.QDialogButtonBox()
+        self.buttons.addButton(QtWidgets.QDialogButtonBox.Ok)
+        self.buttons.addButton(QtWidgets.QDialogButtonBox.Cancel)
+        self.buttons.addButton("Disconnect", QtWidgets.QDialogButtonBox.DestructiveRole)
+        layout.addWidget(self.buttons)
 
     def exec(self):
         return super().exec()

--- a/nurse/grid.py
+++ b/nurse/grid.py
@@ -77,7 +77,7 @@ class PatientTitleWidget(QtWidgets.QWidget):
         layout = HBoxLayout(self)
 
         # Temporary setting - filled in later
-        self.name_btn = QtWidgets.QPushButton(f"{self.gen.record.nurse_id}")
+        self.name_btn = QtWidgets.QPushButton("i")
         layout.addWidget(self.name_btn)
 
         self.name_edit = QtWidgets.QLineEdit()

--- a/nurse/grid.py
+++ b/nurse/grid.py
@@ -158,7 +158,6 @@ class PatientSensor(QtGui.QFrame, DragDropGridMixin):
 
     @Slot()
     def click_number(self):
-        print("Not implemented")
         dialog = GeneratorDialog()
         if dialog.exec():
             pass

--- a/nurse/grid.py
+++ b/nurse/grid.py
@@ -19,10 +19,9 @@ from nurse.qt import (
 
 from nurse.common import GraphInfo, INFO_STRINGS
 from nurse.dragdrop import DragDropGridMixin
+from nurse.generator_dialog import GeneratorDialog
 
 from processor.generator import Status, Generator
-from processor.remote_generator import RemoteGenerator
-from nurse.connection_dialog import ConnectionDialog
 
 
 class NumberLabel(QtWidgets.QLabel):
@@ -124,7 +123,6 @@ class PatientSensor(QtGui.QFrame, DragDropGridMixin):
         self.last_status_change = int(1000 * datetime.now().timestamp())
         self.gen: Generator = gen
         self.current_alarms: Dict[str, Any] = {}
-        self.sensor_id = -1
         self.i = i
 
         layout = HBoxLayout(self)
@@ -160,23 +158,10 @@ class PatientSensor(QtGui.QFrame, DragDropGridMixin):
 
     @Slot()
     def click_number(self):
-        if isinstance(self.gen, RemoteGenerator):
-            dialog = ConnectionDialog(
-                self.parent().listener, self.sensor_id, self.gen.address
-            )
-            if dialog.exec():
-                self.gen.address = dialog.connection_address()
-        else:
-            dialog = ConnectionDialog(
-                self.parent().listener, self.sensor_id, "tcp://127.0.0.1:8100"
-            )
-            if dialog.exec():
-                logger = self.gen.logger
-                self.gen.close()
-                self.gen = RemoteGenerator(
-                    address=dialog.connection_address(), logger=logger
-                )
-                self.gen.run()
+        print("Not implemented")
+        dialog = GeneratorDialog()
+        if dialog.exec():
+            pass
 
     def set_plot(self):
         assert len(self.curves) == 0
@@ -219,11 +204,6 @@ class PatientSensor(QtGui.QFrame, DragDropGridMixin):
 
             # Change of status requires a background color change
             self.status = self.gen.status
-
-            sensor_id = self.gen.sensor_id
-            if self.sensor_id != sensor_id:
-                self.title_widget.name_btn.setText(f"{sensor_id}:")
-                self.sensor_id = sensor_id
 
             alarming_quanities = {key.rsplit(maxsplit=1)[0] for key in self.gen.alarms}
 

--- a/nurse/grid.py
+++ b/nurse/grid.py
@@ -20,6 +20,7 @@ from nurse.qt import (
 from nurse.common import GraphInfo, INFO_STRINGS
 from nurse.dragdrop import DragDropGridMixin
 from nurse.generator_dialog import GeneratorDialog
+from nurse.gen_record_gui import GenRecordGUI
 
 from processor.generator import Status, Generator
 
@@ -73,6 +74,8 @@ class PatientTitleWidget(QtWidgets.QWidget):
     def __init__(self, gen: Generator):
         super().__init__()
         self.gen = gen
+        record: GenRecordGUI
+        record = self.gen.record  # type: ignore
 
         layout = HBoxLayout(self)
 
@@ -83,7 +86,12 @@ class PatientTitleWidget(QtWidgets.QWidget):
         self.name_edit.setText(self.gen.record.title)
         self.name_edit.setPlaceholderText(self.gen.record.box_name)
         self.name_edit.editingFinished.connect(self.update_title)
+        record.master_signal.title_changed.connect(self.external_update_title)
         layout.addWidget(self.name_edit)
+
+    @Slot()
+    def external_update_title(self):
+        self.name_edit.setText(self.gen.record.title)
 
     @Slot()
     def update_title(self):
@@ -185,7 +193,7 @@ class PatientSensor(QtGui.QFrame, DragDropGridMixin):
 
             graph.getAxis("left").setStyle(
                 tickTextOffset=2,
-                textFillLimits=[(2, 1),],  ## Never have less than two ticks
+                textFillLimits=[(2, 1),],  # Never have less than two ticks
             )
 
             if i != len(gis.graph_labels) - 1:

--- a/nurse/grid.py
+++ b/nurse/grid.py
@@ -70,6 +70,10 @@ class NumbersWidget(QtWidgets.QWidget):
         return iter(self.val_widgets)
 
 
+class TinyBoxName(QtWidgets.QLabel):
+    pass
+
+
 class PatientTitleWidget(QtWidgets.QWidget):
     def __init__(self, gen: Generator):
         super().__init__()
@@ -84,10 +88,17 @@ class PatientTitleWidget(QtWidgets.QWidget):
 
         self.name_edit = QtWidgets.QLineEdit()
         self.name_edit.setText(self.gen.record.title)
-        self.name_edit.setPlaceholderText(self.gen.record.box_name)
+        self.name_edit.setPlaceholderText("Please enter title")
         self.name_edit.editingFinished.connect(self.update_title)
         record.master_signal.title_changed.connect(self.external_update_title)
-        layout.addWidget(self.name_edit)
+        layout.addWidget(self.name_edit, 1)
+
+        self.box_name = TinyBoxName(
+            "Box Name:\nUnknown"
+            if gen.record.mac is None
+            else "\n".join(gen.record.box_name.split())
+        )
+        layout.addWidget(self.box_name)
 
     @Slot()
     def external_update_title(self):

--- a/nurse/grid.py
+++ b/nurse/grid.py
@@ -76,7 +76,6 @@ class PatientTitleWidget(QtWidgets.QWidget):
 
         layout = HBoxLayout(self)
 
-        # Temporary setting - filled in later
         self.name_btn = QtWidgets.QPushButton("i")
         layout.addWidget(self.name_btn)
 

--- a/nurse/grid.py
+++ b/nurse/grid.py
@@ -77,7 +77,7 @@ class PatientTitleWidget(QtWidgets.QWidget):
         layout = HBoxLayout(self)
 
         # Temporary setting - filled in later
-        self.name_btn = QtWidgets.QPushButton(f"{self.gen.record.sid}:")
+        self.name_btn = QtWidgets.QPushButton(f"{self.gen.record.nurse_id}")
         layout.addWidget(self.name_btn)
 
         self.name_edit = QtWidgets.QLineEdit()

--- a/nurse/grid.py
+++ b/nurse/grid.py
@@ -168,7 +168,7 @@ class PatientSensor(QtGui.QFrame, DragDropGridMixin):
 
     @Slot()
     def click_number(self):
-        dialog = GeneratorDialog()
+        dialog = GeneratorDialog(self.gen)
         if dialog.exec():
             pass
 

--- a/nurse/grid.py
+++ b/nurse/grid.py
@@ -15,6 +15,7 @@ from nurse.qt import (
     HBoxLayout,
     VBoxLayout,
     FormLayout,
+    BoxName,
 )
 
 from nurse.common import GraphInfo, INFO_STRINGS
@@ -70,10 +71,6 @@ class NumbersWidget(QtWidgets.QWidget):
         return iter(self.val_widgets)
 
 
-class TinyBoxName(QtWidgets.QLabel):
-    pass
-
-
 class PatientTitleWidget(QtWidgets.QWidget):
     def __init__(self, gen: Generator):
         super().__init__()
@@ -93,7 +90,7 @@ class PatientTitleWidget(QtWidgets.QWidget):
         record.master_signal.title_changed.connect(self.external_update_title)
         layout.addWidget(self.name_edit, 1)
 
-        self.box_name = TinyBoxName(gen.record.stacked_name)
+        self.box_name = BoxName(gen.record.stacked_name)
         layout.addWidget(self.box_name)
         record.master_signal.mac_changed.connect(self.external_update_mac)
 

--- a/nurse/grid.py
+++ b/nurse/grid.py
@@ -93,16 +93,17 @@ class PatientTitleWidget(QtWidgets.QWidget):
         record.master_signal.title_changed.connect(self.external_update_title)
         layout.addWidget(self.name_edit, 1)
 
-        self.box_name = TinyBoxName(
-            "Box Name:\nUnknown"
-            if gen.record.mac is None
-            else "\n".join(gen.record.box_name.split())
-        )
+        self.box_name = TinyBoxName(gen.record.stacked_name)
         layout.addWidget(self.box_name)
+        record.master_signal.mac_changed.connect(self.external_update_mac)
 
     @Slot()
     def external_update_title(self):
         self.name_edit.setText(self.gen.record.title)
+
+    @Slot()
+    def external_update_mac(self):
+        self.box_name.setText(self.gen.record.stacked_name)
 
     @Slot()
     def update_title(self):

--- a/nurse/header.py
+++ b/nurse/header.py
@@ -1,8 +1,15 @@
+from __future__ import annotations
+
 from nurse.qt import QtWidgets, QtGui, Qt, Slot, HBoxLayout
 from nurse.common import GraphInfo
 from datetime import datetime
 
 from nurse.limits_dialog import LimitDialog
+from nurse.help_dialog import HelpDialog
+
+
+class HeaderButton(QtWidgets.QPushButton):
+    pass
 
 
 class PrincetonLogoWidget(QtWidgets.QWidget):
@@ -99,7 +106,9 @@ class GraphLabelWidget(QtWidgets.QWidget):
 
 
 class HeaderWidget(QtWidgets.QWidget):
-    pass
+    @Slot()
+    def call_for_help(self):
+        HelpDialog().exec()
 
 
 class MainHeaderWidget(HeaderWidget):
@@ -115,13 +124,18 @@ class MainHeaderWidget(HeaderWidget):
         graph_info = GraphLabelWidget()
         layout.addWidget(graph_info)
 
-        self.add_btn = QtWidgets.QPushButton("+")
+        self.add_btn = HeaderButton("+")
         layout.addWidget(self.add_btn)
+
+        self.help_btn = HeaderButton("?")
+        self.help_btn.setObjectName("help_btn")
+        self.help_btn.clicked.connect(self.call_for_help)
+        layout.addWidget(self.help_btn)
 
         nsf_logo = NSFLogoWidget()
         layout.addWidget(nsf_logo)
 
-        self.fs_exit = QtWidgets.QPushButton("X")
+        self.fs_exit = HeaderButton("X")
         self.fs_exit.setObjectName("exit_btn")
         self.fs_exit.setVisible(False)
         layout.addWidget(self.fs_exit)
@@ -149,6 +163,11 @@ class DrilldownHeaderWidget(HeaderWidget):
         self.return_btn = QtWidgets.QPushButton("Return to main view")
         self.return_btn.setObjectName("return_btn")
         layout.addWidget(self.return_btn, 0, Qt.AlignVCenter)
+
+        self.help_btn = HeaderButton("?")
+        self.help_btn.setObjectName("help_btn")
+        self.help_btn.clicked.connect(self.call_for_help)
+        layout.addWidget(self.help_btn)
 
         nsf_logo = NSFLogoWidget()
         layout.addWidget(nsf_logo)

--- a/nurse/header.py
+++ b/nurse/header.py
@@ -106,9 +106,7 @@ class GraphLabelWidget(QtWidgets.QWidget):
 
 
 class HeaderWidget(QtWidgets.QWidget):
-    @Slot()
-    def call_for_help(self):
-        HelpDialog().exec()
+    pass
 
 
 class MainHeaderWidget(HeaderWidget):
@@ -145,6 +143,10 @@ class MainHeaderWidget(HeaderWidget):
 
         # dt_info = DateTimeWidget()
         # layout.addWidget(dt_info, 6) # Would need to be updated periodically
+
+    @Slot()
+    def call_for_help(self):
+        HelpDialog(0).exec()
 
 
 class DrilldownHeaderWidget(HeaderWidget):
@@ -186,3 +188,7 @@ class DrilldownHeaderWidget(HeaderWidget):
             self.mode_btn.setText("Mode: Overwrite")
         else:
             self.mode_btn.setText("Mode: Scroll")
+
+    @Slot()
+    def call_for_help(self):
+        HelpDialog(1).exec()

--- a/nurse/header.py
+++ b/nurse/header.py
@@ -125,10 +125,12 @@ class MainHeaderWidget(HeaderWidget):
         layout.addWidget(graph_info)
 
         self.add_btn = HeaderButton("+")
+        self.add_btn.setToolTip("Add a device")
         layout.addWidget(self.add_btn)
 
         self.help_btn = HeaderButton("?")
         self.help_btn.setObjectName("help_btn")
+        self.help_btn.setToolTip("Get help")
         self.help_btn.clicked.connect(self.call_for_help)
         layout.addWidget(self.help_btn)
 
@@ -137,6 +139,7 @@ class MainHeaderWidget(HeaderWidget):
 
         self.fs_exit = HeaderButton("X")
         self.fs_exit.setObjectName("exit_btn")
+        self.fs_exit.setToolTip("Exit")
         self.fs_exit.setVisible(False)
         layout.addWidget(self.fs_exit)
 
@@ -166,6 +169,7 @@ class DrilldownHeaderWidget(HeaderWidget):
 
         self.help_btn = HeaderButton("?")
         self.help_btn.setObjectName("help_btn")
+        self.help_btn.setToolTip("Get help")
         self.help_btn.clicked.connect(self.call_for_help)
         layout.addWidget(self.help_btn)
 

--- a/nurse/help_dialog.py
+++ b/nurse/help_dialog.py
@@ -1,19 +1,56 @@
 from __future__ import annotations
 
-from nurse.qt import QtWidgets, QtGui, Qt, Slot, HBoxLayout
-from nurse.common import GraphInfo
-from datetime import datetime
+import sys
+from nurse.qt import QtWidgets, QtGui, QtCore, Qt, Slot, HBoxLayout
 
 
 class HelpDialog(QtWidgets.QDialog):
-    def __init__(self):
+    def __init__(self, default_tab: int = 0):
         super().__init__()
+        self.setWindowTitle("Help")
 
         layout = QtWidgets.QVBoxLayout(self)
 
-        layout.addWidget(QtWidgets.QLabel("Help"))
+        tabs = QtWidgets.QTabWidget()
+        layout.addWidget(tabs)
+
+        main_help = QtWidgets.QLabel(
+            r"""
+        <p>At the top of the screen, you have the main menu bar. The three color coded graph labels after "Graph Settings" are clickable;
+        clicking on them opens a limit selection dialog that can adjust the graph limits for all sensors. The next item on the menu is a "+" symbol,
+        and clicking on that will open the add sensor dialog (advanced, usually not needed). Finally, you will see the "?" button that brought you here.</p>
+
+        <p> The main screen has a grid of sensors. You can click the "i" to view information. You can click on the title to set it.
+        You can click/tap on a sensor to enter the "drilldown"
+        for that sensor. You can drag one sensor on another to swap their positions.</p>
+        """
+        )
+        main_help.setWordWrap(True)
+        tabs.addTab(main_help, "Main screen")
+
+        drilldown_help = QtWidgets.QLabel(
+            r"""
+        <p> In the drilldown screen, there are a few new items in the top bar: </p>
+        <ul>
+        <li>Mode: can be set to Scroll or Overwrite</li>
+        <li>Freeze: Will stop the screen from updating when selected</li>
+        <li>Return to main window: Leave the drilldown</li>
+        </ul>
+        """
+        )
+        drilldown_help.setWordWrap(True)
+        tabs.addTab(drilldown_help, "Drilldown")
 
         self.button = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.Ok)
         layout.addWidget(self.button)
 
         self.button.accepted.connect(self.close)
+
+        tabs.setCurrentIndex(default_tab)
+
+
+if __name__ == "__main__":
+    app = QtWidgets.QApplication(sys.argv)
+    dialog = HelpDialog()
+    dialog.show()
+    sys.exit(app.exec_())

--- a/nurse/help_dialog.py
+++ b/nurse/help_dialog.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from nurse.qt import QtWidgets, QtGui, Qt, Slot, HBoxLayout
+from nurse.common import GraphInfo
+from datetime import datetime
+
+
+class HelpDialog(QtWidgets.QDialog):
+    def __init__(self):
+        super().__init__()
+
+        layout = QtWidgets.QVBoxLayout(self)
+
+        layout.addWidget(QtWidgets.QLabel("Help"))
+
+        self.button = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.Ok)
+        layout.addWidget(self.button)

--- a/nurse/help_dialog.py
+++ b/nurse/help_dialog.py
@@ -15,3 +15,5 @@ class HelpDialog(QtWidgets.QDialog):
 
         self.button = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.Ok)
         layout.addWidget(self.button)
+
+        self.button.accepted.connect(self.close)

--- a/nurse/qt.py
+++ b/nurse/qt.py
@@ -16,6 +16,11 @@ except AttributeError:
     Slot = QtCore.pyqtSlot
     Signal = QtCore.pyqtSignal
 
+
+class BoxName(QtWidgets.QLabel):
+    pass
+
+
 # Layout factory functions
 def HBoxLayout(*args, **kwargs):
     layout = QtWidgets.QHBoxLayout(*args, **kwargs)

--- a/nurse/style.css
+++ b/nurse/style.css
@@ -17,6 +17,11 @@ QPushButton, QCheckBox {
   background-color: #32373C;
 }
 
+.BoxName {
+  color: yellow;
+  font-style:italic;
+}
+
 
 /* Header design */
 
@@ -113,10 +118,8 @@ PatientSensor > PatientTitleWidget > QLineEdit {
   font-size: 16pt;
 }
 
-PatientSensor > PatientTitleWidget > TinyBoxName {
-  color: floralwhite;
+PatientSensor > PatientTitleWidget > BoxName {
   font-size: 10pt;
-  font-style: italic;
   min-width: 60px;
 }
 
@@ -251,8 +254,9 @@ PatientDrilldownWidget > PatientTitle > QPushButton {
   border-radius: 18px;
 }
 
-PatientDrilldownWidget QLabel#TitleWarning {
-  color: #AAA;
+PatientDrilldownWidget BoxName {
+  font-size:16pt;
+  font-weight:bold;
 }
 
 /* Drilldown alarm grid (also see above in general colors) */
@@ -269,10 +273,11 @@ AlarmBox {
   color: white;
 }
 
+/* BoxName style repeated here */
 AlarmBox[nurse_id="auto"] {
     font-size: 13pt;
     font-style: italic;
-    color: floralwhite;
+    color: yellow;
 }
 
 AlarmBox[alert_status="OK"]:hover,

--- a/nurse/style.css
+++ b/nurse/style.css
@@ -110,7 +110,14 @@ PatientSensor > PatientTitleWidget > QLineEdit {
   padding: 1px 3px;
   margin-right: 5px;
   font-weight: bold;
-  font-size: 14pt;
+  font-size: 16pt;
+}
+
+PatientSensor > PatientTitleWidget > TinyBoxName {
+  color: floralwhite;
+  font-size: 10pt;
+  font-style: italic;
+  min-width: 60px;
 }
 
 /* Alert colors */
@@ -244,6 +251,10 @@ PatientDrilldownWidget > PatientTitle > QPushButton {
   border-radius: 18px;
 }
 
+PatientDrilldownWidget QLabel#TitleWarning {
+  color: #AAA;
+}
+
 /* Drilldown alarm grid (also see above in general colors) */
 
 AlarmBox {
@@ -255,10 +266,13 @@ AlarmBox {
   max-height: 30px;
   font-weight: bold;
   font-size: 20pt;
+  color: white;
 }
 
 AlarmBox[nurse_id="auto"] {
-    font-size: 14px;
+    font-size: 13pt;
+    font-style: italic;
+    color: floralwhite;
 }
 
 AlarmBox[alert_status="OK"]:hover,

--- a/nurse/style.css
+++ b/nurse/style.css
@@ -254,7 +254,11 @@ AlarmBox {
   min-height: 30px;
   max-height: 30px;
   font-weight: bold;
-  font-size: 14pt;
+  font-size: 20pt;
+}
+
+AlarmBox[nurse_id="auto"] {
+    font-size: 14px;
 }
 
 AlarmBox[alert_status="OK"]:hover,

--- a/nurse/style.css
+++ b/nurse/style.css
@@ -99,26 +99,32 @@ PatientSensor > PatientTitleWidget > QLineEdit {
 
 /* Alert colors */
 
-PatientSensor[alert_status="OK"] > PatientTitleWidget > QPushButton {
+/* Default */
+PatientSensor[alert_status="OK"] > PatientTitleWidget > QPushButton,
+PatientDrilldownWidget[alert_status="OK"] > PatientTitle > QPushButton {
   background-color: 'transparent';
 }
 
-PatientSensor[alert_status="OK"] > PatientTitleWidget > QPushButton:hover {
+/* Default hover */
+PatientSensor[alert_status="OK"] > PatientTitleWidget > QPushButton:hover,
+PatientDrilldownWidget[alert_status="OK"] > PatientTitle > QPushButton:hover {
   background-color: #303030;
 }
 
+/* Default main title */
 PatientSensor[alert_status="OK"] > PatientTitleWidget > QLineEdit,
 PatientDrilldownWidget[alert_status="OK"] > PatientTitle > QLineEdit {
   background-color: #32373C;
 }
 
 PatientSensor[alert_status="ALERT"] > PatientTitleWidget > QPushButton,
-PatientDrilldownWidget[alert_status="ALERT"] > PatientTitle > QLabel,
+PatientDrilldownWidget[alert_status="ALERT"] > PatientTitle > QPushButton,
 AlarmBox[alert_status="ALERT"] {
   background-color: #ED4337;
 }
 
 PatientSensor[alert_status="ALERT"] > PatientTitleWidget > QPushButton:hover,
+PatientDrilldownWidget[alert_status="ALERT"] > PatientTitle > QPushButton:hover,
 AlarmBox[alert_status="ALERT"]:hover,
 AlarmBox[alert_status="ALERT_ACTIVE"] {
   background-color: #AD2337;
@@ -131,12 +137,13 @@ PatientDrilldownWidget[alert_status="ALERT"] > PatientTitle > QLineEdit {
 
 
 PatientSensor[alert_status="DISCON"] > PatientTitleWidget > QPushButton,
-PatientDrilldownWidget[alert_status="DISCON"] > PatientTitle > QLabel,
+PatientDrilldownWidget[alert_status="DISCON"] > PatientTitle > QPushButton,
 AlarmBox[alert_status="DISCON"] {
   background-color: #4CB3EF;
 }
 
 PatientSensor[alert_status="DISCON"] > PatientTitleWidget > QPushButton:hover,
+PatientDrilldownWidget[alert_status="DISCON"] > PatientTitle > QPushButton:hover,
 AlarmBox[alert_status="DISCON"]:hover,
 AlarmBox[alert_status="DISCON_ACTIVE"] {
   background-color: #2C93AF;
@@ -203,7 +210,7 @@ PatientDrilldownWidget {
   background-color: black;
 }
 
-PatientDrilldownWidget > PatientTitle > QLabel,
+PatientDrilldownWidget > PatientTitle > QPushButton,
 PatientDrilldownWidget > PatientTitle > QLineEdit {
   margin: 5px;
   padding: 3px;

--- a/nurse/style.css
+++ b/nurse/style.css
@@ -1,3 +1,5 @@
+/* Colors: http://www.colors.commutercreative.com/grid/ */
+
 * {
   background-color: transparent;
   margin: 0px;
@@ -41,9 +43,24 @@ HeaderWidget > PrincetonLogoWidget > QLabel {
   font-family: Times;
 }
 
-HeaderWidget > QPushButton#exit_btn {
-  background-color: red;
-  min-width: 26px;
+HeaderButton {
+  min-width: 28px;
+}
+
+HeaderButton#exit_btn {
+  background-color: Crimson;
+}
+
+HeaderButton#exit_btn:hover {
+  background-color: Crimson;
+}
+
+HeaderButton#help_btn {
+  background-color: MediumOrchid;
+}
+
+HeaderButton#help_btn:hover {
+  background-color: DarkOrchid;
 }
 
 DrilldownHeaderWidget QPushButton, DrilldownHeaderWidget QCheckBox {

--- a/nurse/style.css
+++ b/nurse/style.css
@@ -96,14 +96,13 @@ GraphLabelWidget > QPushButton[graph="volume"]{
 
 PatientSensor > PatientTitleWidget > QPushButton {
   color: white;
-  font: bold;
+  font: bold italic;
+  font-family: Times;
   font-size: 20px;
+  width: 20px;
+  height: 20px;
   border: none;
-  border-radius: 3px;
-  padding-top: 0px;
-  padding-bottom: 0px;
-  padding-left: 5px;
-  padding-right: 5px;
+  border-radius: 10px;
   margin-right: 3px;
 }
 
@@ -227,7 +226,6 @@ PatientDrilldownWidget {
   background-color: black;
 }
 
-PatientDrilldownWidget > PatientTitle > QPushButton,
 PatientDrilldownWidget > PatientTitle > QLineEdit {
   margin: 5px;
   padding: 3px;
@@ -236,17 +234,27 @@ PatientDrilldownWidget > PatientTitle > QLineEdit {
   border-radius: 3px;
 }
 
+PatientDrilldownWidget > PatientTitle > QPushButton {
+  margin: 5px;
+  font-size: 36px;
+  font: bold italic;
+  font-family: Times;
+  width: 36px;
+  height: 36px;
+  border-radius: 18px;
+}
+
 /* Drilldown alarm grid (also see above in general colors) */
 
 AlarmBox {
   background-color: #606060;
   margin: 2px;
-  min-width: 50px;
-  min-height: 50px;
-  max-width: 50px;
-  max-height: 50px;
+  min-width: 100px;
+  max-width: 150px;
+  min-height: 30px;
+  max-height: 30px;
   font-weight: bold;
-  font-size: 24pt;
+  font-size: 14pt;
 }
 
 AlarmBox[alert_status="OK"]:hover,

--- a/nursegui.py
+++ b/nursegui.py
@@ -170,7 +170,7 @@ class MainStack(QtWidgets.QWidget):
         i, j = self._get_next_empty()
 
         drilldown: DrilldownWidget = self.parent().parent().drilldown
-        drilldown.add_alarm_box()
+        drilldown.add_alarm_box(gen, i)
 
         graph = PatientSensor(i=ind, gen=gen)
         self.graphs.append(graph)

--- a/nursegui.py
+++ b/nursegui.py
@@ -109,12 +109,6 @@ class MainStack(QtWidgets.QWidget):
         self.qTimer.setSingleShot(True)
         self.qTimer.start()
 
-        self.matching_dialog = MatchingDialog()
-        self.matching_alert_timer = QtCore.QTimer()
-        self.matching_alert_timer.timeout.connect(self.check_for_matching)
-        self.matching_alert_timer.setInterval(1000)
-        self.matching_alert_timer.start(1000)
-
         self.header.add_btn.clicked.connect(self.add_item_dialog)
 
         self.injector = InjectDiscovery()
@@ -192,28 +186,6 @@ class MainStack(QtWidgets.QWidget):
             self.qTimer.start(50)
         else:
             self.qTimer.start(500)
-
-    @Slot()
-    def check_for_matching(self) -> None:
-        ids = Counter(graph.gen.sensor_id for graph in self.graphs)
-        too_many = {k: v for k, v in ids.items() if v > 1 and k != 0}
-        if too_many:
-            self.matching_dialog.setText(
-                "/n".join(
-                    f"Too many ({v}) sensors with ID: {k}" for k, v in too_many.items()
-                )
-            )
-            if not self.matching_dialog.isVisible():
-                self.matching_dialog.open()
-                self.matching_dialog.setWindowFlags(
-                    self.matching_dialog.windowFlags()
-                    | Qt.CustomizeWindowHint
-                    | Qt.WindowTitleHint
-                    | Qt.WindowStaysOnTopHint
-                )
-        else:
-            if self.matching_dialog.isVisible():
-                self.matching_dialog.close()
 
 
 class MatchingDialog(QtWidgets.QDialog):

--- a/nursegui.py
+++ b/nursegui.py
@@ -170,7 +170,7 @@ class MainStack(QtWidgets.QWidget):
         i, j = self._get_next_empty()
 
         drilldown: DrilldownWidget = self.parent().parent().drilldown
-        drilldown.add_alarm_box(gen, i)
+        drilldown.add_alarm_box(gen)
 
         graph = PatientSensor(i=ind, gen=gen)
         self.graphs.append(graph)

--- a/nursegui.py
+++ b/nursegui.py
@@ -170,7 +170,7 @@ class MainStack(QtWidgets.QWidget):
         i, j = self._get_next_empty()
 
         drilldown: DrilldownWidget = self.parent().parent().drilldown
-        drilldown.add_alarm_box(gen)
+        drilldown.add_alarm_box(gen, i=ind)
 
         graph = PatientSensor(i=ind, gen=gen)
         self.graphs.append(graph)
@@ -257,7 +257,7 @@ class MainWindow(QtWidgets.QMainWindow):
         super().closeEvent(evt)
 
 
-def main(argv, *, window: bool, debug: bool, **kwargs):
+def main(argv, *, window: bool, **kwargs):
 
     if "Fusion" in QtWidgets.QStyleFactory.keys():
         QtWidgets.QApplication.setStyle(QtWidgets.QStyleFactory.create("Fusion"))
@@ -333,5 +333,4 @@ if __name__ == "__main__":
         sim=args.sim,
         displays=args.displays,
         window=args.window,
-        debug=args.debug,
     )

--- a/nursegui.py
+++ b/nursegui.py
@@ -33,6 +33,7 @@ from nurse.connection_dialog import ConnectionDialog
 from processor.generator import Generator
 from processor.local_generator import LocalGenerator
 from processor.remote_generator import RemoteGenerator
+from nurse.gen_record_gui import GenRecordGUI
 from processor.argparse import ArgumentParser
 from processor.listener import FindBroadcasts
 from processor.logging import make_nested_logger
@@ -91,10 +92,16 @@ class MainStack(QtWidgets.QWidget):
                 local_logger = make_nested_logger(i)
                 gen = (
                     RemoteGenerator(
-                        address=addr or "tcp://127.0.0.1:8100", logger=local_logger
+                        address=addr or "tcp://127.0.0.1:8100",
+                        logger=local_logger,
+                        gen_record=GenRecordGUI(local_logger),
                     )
                     if not sim
-                    else LocalGenerator(i=i + 1, logger=local_logger)
+                    else LocalGenerator(
+                        i=i + 1,
+                        logger=local_logger,
+                        gen_record=GenRecordGUI(local_logger),
+                    )
                 )
                 gen.run()  # Close must be called
 
@@ -138,7 +145,9 @@ class MainStack(QtWidgets.QWidget):
 
     def add_new_by_address(self, addr: str):
         local_logger = make_nested_logger(len(self.graphs))
-        gen = RemoteGenerator(address=addr, logger=local_logger)
+        gen = RemoteGenerator(
+            address=addr, logger=local_logger, gen_record=GenRecordGUI(local_logger)
+        )
         gen.run()
         self.add_item(gen)
 

--- a/patient/backlight.py
+++ b/patient/backlight.py
@@ -26,29 +26,35 @@ class Backlight:
         shade = self.shade if shade is None else shade
         self.color(shade, shade, shade)
 
-    def red(self, shade: int = None) -> None:
+    def red(self, shade: int = None, *, light=False) -> None:
+        zero = self.shade // 3 if light else 0
         shade = self.shade if shade is None else shade
-        self.color(shade, 0, 0)
+        self.color(shade, zero, zero)
 
-    def green(self, shade: int = None) -> None:
+    def green(self, shade: int = None, *, light=False) -> None:
+        zero = self.shade // 3 if light else 0
         shade = self.shade if shade is None else shade
-        self.color(0, shade, 0)
+        self.color(zero, shade, zero)
 
-    def blue(self, shade: int = None) -> None:
+    def blue(self, shade: int = None, *, light=False) -> None:
+        zero = self.shade // 3 if light else 0
         shade = self.shade if shade is None else shade
-        self.color(0, 0, shade)
+        self.color(zero, zero, shade)
 
-    def cyan(self, shade: int = None) -> None:
+    def cyan(self, shade: int = None, *, light=False) -> None:
+        zero = self.shade // 3 if light else 0
         shade = self.shade if shade is None else shade
-        self.color(0, shade, shade)
+        self.color(zero, shade, shade)
 
-    def magenta(self, shade: int = None) -> None:
+    def magenta(self, shade: int = None, *, light=False) -> None:
+        zero = self.shade // 3 if light else 0
         shade = self.shade if shade is None else shade
-        self.color(shade, 0, shade)
+        self.color(shade, zero, shade)
 
-    def yellow(self, shade: int = None) -> None:
+    def yellow(self, shade: int = None, *, light=False) -> None:
+        zero = self.shade // 3 if light else 0
         shade = self.shade if shade is None else shade
-        self.color(shade, shade, 0)
+        self.color(shade, shade, zero)
 
     def orange(self, shade: int = None) -> None:
         shade = self.shade if shade is None else shade

--- a/patient/backlight.py
+++ b/patient/backlight.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import pigpio
 from typing import Optional
 
@@ -65,3 +67,8 @@ class Backlight:
 
     def __exit__(self, *exc):
         pass
+
+
+if __name__ == "__main__":
+    with Backlight() as b:
+        b.black()

--- a/patient/backlight.py
+++ b/patient/backlight.py
@@ -23,36 +23,39 @@ class Backlight:
         self.pi.set_PWM_dutycycle(self.PIN_BLUE, blue)
 
     def white(self, shade: int = None) -> None:
-        shade = shade or self.shade
+        shade = self.shade if shade is None else shade
         self.color(shade, shade, shade)
 
     def red(self, shade: int = None) -> None:
-        shade = shade or self.shade
+        shade = self.shade if shade is None else shade
         self.color(shade, 0, 0)
 
     def green(self, shade: int = None) -> None:
-        shade = shade or self.shade
+        shade = self.shade if shade is None else shade
         self.color(0, shade, 0)
 
     def blue(self, shade: int = None) -> None:
-        shade = shade or self.shade
+        shade = self.shade if shade is None else shade
         self.color(0, 0, shade)
 
     def cyan(self, shade: int = None) -> None:
-        shade = shade or self.shade
+        shade = self.shade if shade is None else shade
         self.color(0, shade, shade)
 
     def magenta(self, shade: int = None) -> None:
-        shade = shade or self.shade
+        shade = self.shade if shade is None else shade
         self.color(shade, 0, shade)
 
     def yellow(self, shade: int = None) -> None:
-        shade = shade or self.shade
+        shade = self.shade if shade is None else shade
         self.color(shade, shade, 0)
 
     def orange(self, shade: int = None) -> None:
-        shade = shade or self.shade
-        self.color(shade, shade // 2, 0)
+        shade = self.shade if shade is None else shade
+        self.color(shade, shade // 4, 0)
+
+    def black(self):
+        self.color(0, 0, 0)
 
     def __exit__(self, *exc):
         pass

--- a/patient/lcd.py
+++ b/patient/lcd.py
@@ -108,3 +108,5 @@ if __name__ == "__main__":
     with LCD() as lcd:
         lcd.upper("HELLO", Align.CENTER)
         lcd.lower("WORLD", Align.CENTER)
+        time.sleep(1)
+        lcd.clear()

--- a/patient/mac_address.py
+++ b/patient/mac_address.py
@@ -1,6 +1,7 @@
 from functools import lru_cache
 import time
 from pathlib import Path
+from processor.device_names import address_to_name
 
 import logging
 
@@ -22,3 +23,11 @@ def get_mac_addr() -> str:
             return mac
         except IOError:
             time.sleep(1)
+
+
+@lru_cache(1)
+def get_box_name() -> str:
+    try:
+        return address_to_name(get_mac_addr()).title()
+    except ValueError:
+        return "<unknown>"

--- a/patient/rotary.py
+++ b/patient/rotary.py
@@ -141,8 +141,13 @@ class Rotary(LiveRotary, MechanicalRotary):
         self._slow_turn = (self._slow_turn + dir.value) % (
             len(self.config) * self._change_rate
         )
+
+        old_current = self._current
         self._current = self._slow_turn // self._change_rate
-        self.value().active()
+
+        # This resets "auto-reset" settings (reset, advanced) when they are selected
+        if self._current != old_current:
+            self.value().active()
 
     def pushed_turn(self, dir: Dir) -> None:
         if dir == Dir.CLOCKWISE:

--- a/patient/rotary.py
+++ b/patient/rotary.py
@@ -110,6 +110,8 @@ class MechanicalRotary:
 
         if ch == pinSW and level == 0:  # falling edge
             self.push()
+        elif ch == pinSW and level == 1:  # rising edge
+            self.release()
 
     def pushed_turn(self, dir: Dir) -> None:
         pass
@@ -118,6 +120,9 @@ class MechanicalRotary:
         pass
 
     def push(self) -> None:
+        pass
+
+    def release(self) -> None:
         pass
 
 
@@ -158,6 +163,9 @@ class Rotary(LiveRotary, MechanicalRotary):
         self.changed()
 
     def push(self) -> None:
+        pass
+
+    def release(self) -> None:
         pass
 
     def key(self) -> str:

--- a/patient/rotary_gui.py
+++ b/patient/rotary_gui.py
@@ -1,11 +1,11 @@
 from patient.rotary_live import LiveRotary
 from processor.setting import Setting, SelectionSetting, IncrSetting
-from processor.display_settings import CurrentSetting
+from processor.display_settings import CurrentSetting, AdvancedSetting
 from processor.generator import Generator
 
 from nurse.qt import QtCore, QtWidgets, Slot, Signal, update_textbox
 
-from typing import Optional, Callable
+from typing import Union
 
 
 class RedrawSettings(QtCore.QObject):
@@ -39,7 +39,9 @@ class SelectionSettingGUI(QtWidgets.QComboBox):
 
 
 class CurrentSettingGUI(QtWidgets.QComboBox):
-    def __init__(self, rotary: RotaryGUI, setting: CurrentSetting):
+    def __init__(
+        self, rotary: RotaryGUI, setting: Union[CurrentSetting, AdvancedSetting]
+    ):
         super().__init__()
         self.setting = setting
         self.rotary = rotary
@@ -130,7 +132,7 @@ class MainWindow(QtWidgets.QMainWindow):
         layout.addLayout(form_layout)
 
         for setting in rotary.values():
-            if isinstance(setting, CurrentSetting):
+            if isinstance(setting, (CurrentSetting, AdvancedSetting)):
                 widget = CurrentSettingGUI(rotary, setting)
             elif isinstance(setting, IncrSetting):
                 widget = IncrSettingGUI(rotary, setting)

--- a/patient/rotary_lcd.py
+++ b/patient/rotary_lcd.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from processor.setting import Setting
-from processor.display_settings import ResetSetting, CurrentSetting
+from processor.display_settings import ResetSetting, CurrentSetting, NameSetting
 from patient.mac_address import get_mac_addr
 from patient.rotary import Rotary, Dir
 from patient.lcd import LCD
@@ -89,8 +89,8 @@ class RotaryLCD(Rotary):
 
     def turn(self, dir: Dir) -> None:
         super().turn(dir)
-        self.upper_display()
         self.lower_display()
+        self.upper_display()
 
     def alert(self) -> None:
         if self.alarms and self.alarm_level == AlarmLevel.OFF:
@@ -102,7 +102,11 @@ class RotaryLCD(Rotary):
             self.buzzer.clear()
             self.alarm_level = AlarmLevel.OFF
 
-        self.lower_display()
+        if isinstance(self.value(), NameSetting):
+            self.upper_display()
+        else:
+            self.lower_display()
+
         super().alert()
 
     def upper_display(self) -> None:
@@ -111,6 +115,14 @@ class RotaryLCD(Rotary):
             print(f"Warning: Truncating {current_name!r}")
             current_name = current_name[:16]
         string = f"{self._current + 1:>2}: {current_name:<16}"
+
+        if self.alarms and isinstance(self.value(), NameSetting):
+            n = len(self.alarms)
+            if n == 1:
+                string = string[:14] + " ALARM"
+            else:
+                string = string[:13] + " ALARMS"
+
         self.lcd.upper(string)
 
     def lower_display(self) -> None:
@@ -119,7 +131,7 @@ class RotaryLCD(Rotary):
         if len(string) > 20:
             print(f"Warning: Truncating {string!r}")
             string = string[:20]
-        if self.alarms:
+        if self.alarms and not isinstance(self.value(), NameSetting):
             n = len(self.alarms)
             if n == 1:
                 string = string[:14] + " ALARM"
@@ -130,8 +142,8 @@ class RotaryLCD(Rotary):
 
     def display(self) -> None:
         self.lcd.clear()
-        self.upper_display()
         self.lower_display()
+        self.upper_display()
 
 
 if __name__ == "__main__":

--- a/patient/rotary_lcd.py
+++ b/patient/rotary_lcd.py
@@ -116,7 +116,7 @@ class RotaryLCD(Rotary):
 
     def upper_display(self) -> None:
         current_name = self.value().lcd_name
-        current_number = f"{self._current + 1:>2}"
+        current_number = f"{self._current + 1}"
         if isinstance(self.value(), AdvancedSetting):
             current_number += chr(ord("a") + self.value()._value % 26)
         length_available = 20 - len(current_number) - 2

--- a/patient/rotary_lcd.py
+++ b/patient/rotary_lcd.py
@@ -25,10 +25,12 @@ class AlarmLevel(enum.Enum):
 
 class RotaryLCD(Rotary):
     def __init__(self, config: Dict[str, Setting], pi: pigpio.pi = None):
-
         super().__init__(config, pi=pi)
+
+        shade = _config["patient"]["brightness"].get(int)
+
         self.lcd = LCD(pi=pi)
-        self.backlight = Backlight(pi=pi)
+        self.backlight = Backlight(shade=shade, pi=pi)
         self.buzzer = Buzzer(pi=pi)
         self.alarm_level: AlarmLevel = AlarmLevel.OFF
         self.buzzer_volume: int = _config["patient"]["buzzer-volume"].get(int)

--- a/patient/rotary_lcd.py
+++ b/patient/rotary_lcd.py
@@ -37,7 +37,6 @@ class RotaryLCD(Rotary):
         self.lower_display()
 
     def __enter__(self) -> RotaryLCD:
-        self._current = 3  # Current Setting
         self.lcd.__enter__()
         self.backlight.__enter__()
         self.buzzer.__enter__()
@@ -67,8 +66,7 @@ class RotaryLCD(Rotary):
 
     def reset(self):
         for key, item in self.config.items():
-            if key != "Sensor ID":
-                item.reset()
+            item.reset()
 
     def push(self) -> None:
         if self.alarm_level == AlarmLevel.LOUD and self.alarms:
@@ -90,7 +88,6 @@ class RotaryLCD(Rotary):
         self.lower_display()
 
     def turn(self, dir: Dir) -> None:
-        # Top display keeps ID number!
         super().turn(dir)
         self.upper_display()
         self.lower_display()
@@ -109,13 +106,11 @@ class RotaryLCD(Rotary):
         super().alert()
 
     def upper_display(self) -> None:
-        ID = self["Sensor ID"].value
-        ID_string = f"#{ID}"
         current_name = self.value().lcd_name
-        if len(current_name) > 17:
+        if len(current_name) > 16:
             print(f"Warning: Truncating {current_name!r}")
-            current_name = current_name[:17]
-        string = f"{current_name:<17}{ID_string:>3}"
+            current_name = current_name[:16]
+        string = f"{self._current + 1:>2}: {current_name:<16}"
         self.lcd.upper(string)
 
     def lower_display(self) -> None:

--- a/patient/rotary_lcd.py
+++ b/patient/rotary_lcd.py
@@ -91,7 +91,7 @@ class RotaryLCD(Rotary):
             value = self.value()
             if isinstance(value, ResetSetting) and value.at_maximum():
                 self.reset()
-            if value.STATIC_UPPER:
+            if not value.STATIC_UPPER:
                 self.upper_display()
             self.lower_display()
 

--- a/patient/rotary_lcd.py
+++ b/patient/rotary_lcd.py
@@ -49,7 +49,6 @@ class RotaryLCD(Rotary):
         self.buzzer.__enter__()
         super().__enter__()
 
-        self.backlight.white()
         return self
 
     def __exit__(self, *exc) -> None:

--- a/patient/rotary_lcd.py
+++ b/patient/rotary_lcd.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 
 from processor.setting import Setting
 from processor.display_settings import ResetSetting, AdvancedSetting, CurrentSetting
-from patient.mac_address import get_mac_addr
-from processor.device_names import address_to_name
 from patient.rotary import Rotary, Dir
 from patient.lcd import LCD
 from patient.backlight import Backlight
@@ -79,13 +77,18 @@ class RotaryLCD(Rotary):
             self.alert()
             super().push()
 
+    def release(self) -> None:
+        value = self.value()
+        if isinstance(value, ResetSetting) and value.at_maximum():
+            self.reset()
+            self.lcd.lower("Reset complete")
+        super().release()
+
     def pushed_turn(self, dir: Dir) -> None:
         with self.lock:
             # Top display keeps ID number!
             super().pushed_turn(dir)
             value = self.value()
-            if isinstance(value, ResetSetting) and value.at_maximum():
-                self.reset()
             if not value.STATIC_UPPER:
                 self.upper_display()
             self.lower_display()

--- a/patient/rotary_lcd.py
+++ b/patient/rotary_lcd.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from processor.setting import Setting
-from processor.display_settings import ResetSetting, AdvancedSetting
+from processor.display_settings import ResetSetting, AdvancedSetting, CurrentSetting
 from patient.mac_address import get_mac_addr
 from processor.device_names import address_to_name
 from patient.rotary import Rotary, Dir
@@ -38,9 +38,10 @@ class RotaryLCD(Rotary):
         self.lock = threading.Lock()
 
     def external_update(self) -> None:
-        with self.lock:
-            self.upper_display()
-            self.lower_display()
+        if isinstance(self.value(), CurrentSetting):
+            with self.lock:
+                self.upper_display()
+                self.lower_display()
 
     def __enter__(self) -> RotaryLCD:
         self.lcd.__enter__()

--- a/patient/rotary_lcd.py
+++ b/patient/rotary_lcd.py
@@ -50,10 +50,6 @@ class RotaryLCD(Rotary):
         super().__enter__()
 
         self.backlight.white()
-        self.lcd.upper("POVM Box name:")
-        self.lcd.lower("Getting name...")
-        self.lcd.lower(address_to_name(get_mac_addr()).title() + " ")
-        time.sleep(3.5)
         return self
 
     def __exit__(self, *exc) -> None:

--- a/patient/rotary_lcd.py
+++ b/patient/rotary_lcd.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from processor.setting import Setting
 from processor.display_settings import ResetSetting, CurrentSetting, NameSetting
 from patient.mac_address import get_mac_addr
+from processor.device_names import address_to_name
 from patient.rotary import Rotary, Dir
 from patient.lcd import LCD
 from patient.backlight import Backlight
@@ -43,9 +44,9 @@ class RotaryLCD(Rotary):
         super().__enter__()
 
         self.backlight.white()
-        self.lcd.upper("Princeton Open Vent ")
-        self.lcd.lower("Getting address...")
-        self.lcd.lower(get_mac_addr() + " ")
+        self.lcd.upper("POVM Box name:")
+        self.lcd.lower("Getting name...")
+        self.lcd.lower(address_to_name(get_mac_addr()).title() + " ")
         time.sleep(3.5)
         return self
 

--- a/patient_loop.py
+++ b/patient_loop.py
@@ -34,13 +34,18 @@ with ExitStack() as stack:
         signal.signal(signal.SIGTERM, signal.SIG_DFL)
         forever.set()
 
+    rotary.backlight.magenta()
     rotary.lcd.upper("POVM Box name:")
     rotary.lcd.lower("Getting name...")
     rotary.lcd.lower(f"{get_box_name():<20}")
     forever.wait(3)
+
+    rotary.backlight.green(light=True)
     rotary.lcd.upper("Turn to select alarm ")
     rotary.lcd.lower("Push and turn to set ")
     forever.wait(2)
+
+    rotary.backlight.white()
 
     collector = stack.enter_context(Collector(rotary=rotary, port=args.port))
     stack.enter_context(Broadcast("patient_loop", port=args.port, live=5))

--- a/patient_loop.py
+++ b/patient_loop.py
@@ -10,21 +10,21 @@ args = parser.parse_args()
 import signal
 import threading
 from pathlib import Path
+from contextlib import ExitStack
+
 
 from processor.settings import get_live_settings
 from patient.rotary_lcd import RotaryLCD
 from processor.collector import Collector
 from processor.broadcast import Broadcast
+from patient.mac_address import get_box_name
 
 DIR = Path(__file__).parent.resolve()
 
 
 # Initialize LCD
-with RotaryLCD(get_live_settings()) as rotary, Collector(
-    rotary=rotary, port=args.port
-) as collector, Broadcast("patient_loop", port=args.port, live=5):
-    rotary.live_load(DIR / "povm-live.yml")
-    rotary.live_save(DIR / "povm-live.yml", every=10)
+with ExitStack() as stack:
+    rotary = stack.enter_context(RotaryLCD(get_live_settings()))
 
     forever = threading.Event()
 
@@ -33,6 +33,20 @@ with RotaryLCD(get_live_settings()) as rotary, Collector(
         signal.signal(signal.SIGINT, signal.SIG_DFL)
         signal.signal(signal.SIGTERM, signal.SIG_DFL)
         forever.set()
+
+    rotary.lcd.upper("POVM Box name:")
+    rotary.lcd.lower("Getting name...")
+    rotary.lcd.lower(f"{get_box_name():<20}")
+    forever.wait(3)
+    rotary.lcd.upper("Turn to select alarm ")
+    rotary.lcd.lower("Push and turn to set ")
+    forever.wait(2)
+
+    collector = stack.enter_context(Collector(rotary=rotary, port=args.port))
+    stack.enter_context(Broadcast("patient_loop", port=args.port, live=5))
+
+    rotary.live_load(DIR / "povm-live.yml")
+    rotary.live_save(DIR / "povm-live.yml", every=10)
 
     signal.signal(signal.SIGINT, close)
     signal.signal(signal.SIGTERM, close)

--- a/patient_loop.py
+++ b/patient_loop.py
@@ -18,6 +18,7 @@ from processor.broadcast import Broadcast
 
 DIR = Path(__file__).parent.resolve()
 
+
 # Initialize LCD
 with RotaryLCD(get_live_settings()) as rotary, Collector(
     rotary=rotary, port=args.port

--- a/povm.yml
+++ b/povm.yml
@@ -29,7 +29,7 @@ rotary:
     type: Incr
     name: Avg Pressure Min
     default: 5
-    min: 0
+    min: -20
     max: 100
     incr: 1
     unit: cm H20
@@ -38,7 +38,7 @@ rotary:
     type: Incr
     name: Avg Pressure Max
     default: 12
-    min: 1
+    min: -20
     max: 100
     incr: 1
     unit: cm H2O

--- a/povm.yml
+++ b/povm.yml
@@ -47,10 +47,11 @@ rotary:
     type: Incr
     name: RespRate Max
     default: 40
-    min: 5
+    min: 0
     max: 180
     incr: 1
     unit: 1/min
+    zero: "OFF"
 
   Stale Data Timeout:
     type: Incr

--- a/processor/analysis.py
+++ b/processor/analysis.py
@@ -656,6 +656,7 @@ def add_alarms(rotary, _updated, _new_breaths, cumulative):
     if "PIP" in cumulative:
         if (
             "RR Max" in rotary
+            and rotary["RR Max"].value > 0
             and "RR" in cumulative
             and cumulative["RR"] > rotary["RR Max"].value
         ):

--- a/processor/broadcast.py
+++ b/processor/broadcast.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 
 from zeroconf import ServiceInfo, Zeroconf
 from ifaddr import get_adapters  # type: ignore
-from patient.mac_address import get_mac_addr
-from processor.device_names import address_to_name
+from patient.mac_address import get_mac_addr, get_box_name
 from typing import Iterator, Set, Optional
 import threading
 import ipaddress
@@ -64,7 +63,7 @@ class Broadcast:
 
             self.info = ServiceInfo(
                 "_http._tcp.local.",
-                f"Princeton Open Vent Monitor - {address_to_name(get_mac_addr()).title()} - {self.port}._http._tcp.local.",
+                f"Princeton Open Vent Monitor - {get_box_name()} - {self.port}._http._tcp.local.",
                 addresses=[ipaddress.ip_address(ip).packed for ip in addrs],
                 port=self.port,
                 properties={

--- a/processor/broadcast.py
+++ b/processor/broadcast.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from zeroconf import ServiceInfo, Zeroconf
 from ifaddr import get_adapters  # type: ignore
 from patient.mac_address import get_mac_addr
+from processor.device_names import address_to_name
 from typing import Iterator, Set, Optional
 import threading
 import ipaddress
@@ -63,7 +64,7 @@ class Broadcast:
 
             self.info = ServiceInfo(
                 "_http._tcp.local.",
-                f"Princeton Open Vent Monitor {get_mac_addr()} {self.port}._http._tcp.local.",
+                f"Princeton Open Vent Monitor - {address_to_name(get_mac_addr()).title()} - {self.port}._http._tcp.local.",
                 addresses=[ipaddress.ip_address(ip).packed for ip in addrs],
                 port=self.port,
                 properties={

--- a/processor/collector.py
+++ b/processor/collector.py
@@ -88,6 +88,9 @@ class CollectorThread(threading.Thread):
 
                     if self._sn is not None:
                         extra_dict["sid"] = self._sn
+                        if "Advanced" in self.parent.rotary:
+                            setting = self.parent.rotary["Advanced"]
+                            setting.sid = self._sn
 
                     pub_socket.send_json(extra_dict)
 

--- a/processor/config_default.yaml
+++ b/processor/config_default.yaml
@@ -21,7 +21,7 @@ patient:
 rotary-live:
   Reset Setting:
     type: Reset
-    name: Turn to Reset
+    name: PushTurn to Reset
     order: -2
 
   Advanced:

--- a/processor/config_default.yaml
+++ b/processor/config_default.yaml
@@ -18,20 +18,25 @@ patient:
   buzzer-volume: 0
 
 rotary-live:
-  Name:
-    type: Name
-    name: Box name
-    order: -1
-
   Log Filename:
     type: Filename
     name: Log filename
-    order: -3
+    order: -4
 
   Reset Setting:
     type: Reset
     name: Turn to Reset
+    order: -3
+
+  MAC:
+    type: MAC
+    name: MAC Addr
     order: -2
+
+  Name:
+    type: Name
+    name: Box name
+    order: -1
 
   Current Setting:
     type: Current

--- a/processor/config_default.yaml
+++ b/processor/config_default.yaml
@@ -13,25 +13,32 @@ global:
   cumulative-every: 10 # seconds
   run-every: 0.5 # seconds
   window-size: 1500 # 30 seconds @ 50 hertz
-  broadcast-ifaces: [en0, eth0, wlan0]
 
 patient:
   buzzer-volume: 0
 
 rotary-live:
+  Name:
+    type: Name
+    name: Box name
+    order: -1
+
   Log Filename:
     type: Filename
     name: Log filename
+    order: -3
 
   Reset Setting:
     type: Reset
     name: Turn to Reset
+    order: -2
 
   Current Setting:
     type: Current
     default: 3
     items: [1, 3, 5, 10, 20, 30]
     rate: 3
+    order: 0
 
 rotary:
   AvgWindow:
@@ -42,11 +49,5 @@ rotary:
     items: [1, 3, 5, 10, 20, 30]
     unit: s
     rate: 3
+    order: 1
 
-  Sensor ID:
-    type: Incr
-    name: Sensor ID
-    default: 1
-    min: 1
-    max: 24
-    incr: 1

--- a/processor/config_default.yaml
+++ b/processor/config_default.yaml
@@ -15,7 +15,8 @@ global:
   window-size: 1500 # 30 seconds @ 50 hertz
 
 patient:
-  buzzer-volume: 0
+  buzzer-volume: 0 # max 255 (200 ideal)
+  brightness: 200 # max 255
 
 rotary-live:
   Log Filename:

--- a/processor/config_default.yaml
+++ b/processor/config_default.yaml
@@ -19,24 +19,13 @@ patient:
   brightness: 200 # max 255
 
 rotary-live:
-  Log Filename:
-    type: Filename
-    name: Log filename
-    order: -4
-
   Reset Setting:
     type: Reset
     name: Turn to Reset
-    order: -3
-
-  MAC:
-    type: MAC
-    name: MAC Addr
     order: -2
 
-  Name:
-    type: Name
-    name: Box name
+  Advanced:
+    type: Advanced
     order: -1
 
   Current Setting:

--- a/processor/device_names.py
+++ b/processor/device_names.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing_extensions import Final

--- a/processor/display_settings.py
+++ b/processor/display_settings.py
@@ -1,6 +1,8 @@
 from processor.setting import DisplaySetting, SelectionSetting
 from pathlib import Path
 from typing import Optional, List, Sequence
+from patient.mac_address import get_mac_addr
+from processor.device_names import address_to_name
 
 
 DIR = Path(__file__).parent.resolve()
@@ -9,13 +11,35 @@ DIR = Path(__file__).parent.resolve()
 
 class FilenameSetting(DisplaySetting):
     def __init__(self, name: str):
-        super().__init__("", name=name)
+        super().__init__(name=name)
 
     @property
     def value(self) -> str:
         files = sorted(Path(DIR.parent / "device_log").glob("*"))
         string = str(files[-1].name) if files else "No file"
         return string
+
+    # Currently does not work remotely
+    @value.setter
+    def value(self, value: str):
+        self._value = value
+
+    @property
+    def default(self) -> float:
+        return 0.0
+
+    @default.setter
+    def default(self, val: float):
+        pass
+
+
+class NameSetting(DisplaySetting):
+    def __init__(self, name: str):
+        super().__init__(name=name)
+
+    @property
+    def value(self) -> str:
+        return address_to_name(get_mac_addr())
 
     # Currently does not work remotely
     @value.setter

--- a/processor/display_settings.py
+++ b/processor/display_settings.py
@@ -1,4 +1,4 @@
-from processor.setting import DisplaySetting, SelectionSetting
+from processor.setting import SelectionSetting
 from pathlib import Path
 from typing import Optional, List, Sequence
 from patient.mac_address import get_mac_addr

--- a/processor/display_settings.py
+++ b/processor/display_settings.py
@@ -25,7 +25,10 @@ class FilenameSetting(DisplaySetting):
 class NameSetting(DisplaySetting):
     @property
     def value(self) -> str:
-        return address_to_name(get_mac_addr()).title()
+        try:
+            return address_to_name(get_mac_addr()).title()
+        except ValueError:
+            return "<Unknown>"
 
     # Currently does not work remotely
     @value.setter

--- a/processor/display_settings.py
+++ b/processor/display_settings.py
@@ -10,9 +10,6 @@ DIR = Path(__file__).parent.resolve()
 
 
 class FilenameSetting(DisplaySetting):
-    def __init__(self, name: str):
-        super().__init__(name=name)
-
     @property
     def value(self) -> str:
         files = sorted(Path(DIR.parent / "device_log").glob("*"))
@@ -24,35 +21,27 @@ class FilenameSetting(DisplaySetting):
     def value(self, value: str):
         self._value = value
 
-    @property
-    def default(self) -> float:
-        return 0.0
-
-    @default.setter
-    def default(self, val: float):
-        pass
-
 
 class NameSetting(DisplaySetting):
-    def __init__(self, name: str):
-        super().__init__(name=name)
-
     @property
     def value(self) -> str:
-        return address_to_name(get_mac_addr()).capitalize()
+        return address_to_name(get_mac_addr()).title()
 
     # Currently does not work remotely
     @value.setter
     def value(self, value: str):
         self._value = value
 
-    @property
-    def default(self) -> float:
-        return 0.0
 
-    @default.setter
-    def default(self, val: float):
-        pass
+class MACSetting(NameSetting):
+    @property
+    def value(self) -> str:
+        return get_mac_addr()
+
+    # Currently does not work remotely
+    @value.setter
+    def value(self, value: str):
+        self._value = value
 
 
 class CurrentSetting(SelectionSetting):

--- a/processor/display_settings.py
+++ b/processor/display_settings.py
@@ -14,7 +14,7 @@ class AdvancedSetting(SelectionSetting):
 
     def __init__(self, *, rate: int = 2):
 
-        string_listing = ["Box name", "MAC addr", "SensorID", "Log file"]
+        string_listing = ["Box name", "MAC addr", "SensorID", "Log file", "Version"]
 
         # Sensor ID
         self.sid: int = 0
@@ -39,6 +39,8 @@ class AdvancedSetting(SelectionSetting):
             files = sorted(Path(DIR.parent / "device_log").glob("*"))
             string = str(files[-1].name) if files else "No file"
             return string
+        elif self._value == 4:
+            return "Classic: v0.3+"
         else:
             raise NotImplementedError("Setting must be in range 0-3")
 

--- a/processor/display_settings.py
+++ b/processor/display_settings.py
@@ -109,7 +109,10 @@ class CurrentSetting(SelectionSetting):
 class ResetSetting(SelectionSetting):
     def __init__(self, name: str, rate: int = 1):
         super().__init__(
-            0, [f"[{x*'x':8}]" for x in range(9)] + ["RESET"], name=name, rate=rate
+            0,
+            [f"[{x*'x':9}]" for x in range(9)] + ["[  RESET  ]"],
+            name=name,
+            rate=rate,
         )
 
     def active(self) -> None:

--- a/processor/display_settings.py
+++ b/processor/display_settings.py
@@ -39,7 +39,7 @@ class NameSetting(DisplaySetting):
 
     @property
     def value(self) -> str:
-        return address_to_name(get_mac_addr())
+        return address_to_name(get_mac_addr()).capitalize()
 
     # Currently does not work remotely
     @value.setter

--- a/processor/gen_record.py
+++ b/processor/gen_record.py
@@ -42,7 +42,7 @@ class GenRecord:
     @title.setter
     def title(self, value: str):
         if self._nurse_name is None or self._nurse_name != value:
-            self.logger.info(f"Changed title to {self._nurse_name!r}")
+            self.logger.info(f"Changed title to {value!r}")
             self._nurse_name = value
             self.title_changed()  # type: ignore
 

--- a/processor/gen_record.py
+++ b/processor/gen_record.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional
+from typing import Optional, Callable
 from dataclasses import dataclass
 from logging import Logger
 from processor.device_names import address_to_name
@@ -10,26 +10,76 @@ from processor.device_names import address_to_name
 class GenRecord:
     logger: Logger
 
-    mac: Optional[str] = None
+    _mac: Optional[str] = None
+    _sid: int = 0
+
     _nurse_name: Optional[str] = None
     _nurse_id: Optional[str] = None
+
     log: str = ""
 
+    # Change these to add your own callbacks
+    # These *only* run if you set a new value or the first time you set the value!
+    title_changed: Callable[[], None] = lambda: None
+    nid_changed: Callable[[], None] = lambda: None
+    sid_changed: Callable[[], None] = lambda: None
+    mac_changed: Callable[[], None] = lambda: None
+
     @property
-    def name(self) -> str:
+    def box_name(self) -> str:
+        if self.mac is None:
+            return "<unknown>"
+        try:
+            return address_to_name(self.mac).title()
+        except ValueError:
+            return self.mac
+
+    @property
+    def title(self) -> str:
+        """
+        The title to show in the dialog box. Will show box_name if unset.
+        """
         if self._nurse_name is None:
             return self.box_name
         else:
             return self._nurse_name
 
-    @name.setter
-    def name(self, value: str):
-        self._nurse_name = value
-
-    @property
-    def box_name(self):
-        return "<unknown>" if self.mac is None else address_to_name(self.mac).title()
+    @title.setter
+    def title(self, value: str):
+        if self._nurse_name is None or self._nurse_name != value:
+            self.logger.info(f"Changed title to {self._nurse_name!r}")
+            self._nurse_name = value
+            self.title_changed()  # type: ignore
 
     @property
     def nurse_id(self) -> str:
         return "?" if self._nurse_id is None else self._nurse_id
+
+    @nurse_id.setter
+    def nurse_id(self, value: str):
+        if self._nurse_id is None or self._nurse_id != value:
+            self.logger.info(f"Changed short name to {self._nurse_id!r}")
+            self._nurse_id = value
+            self.nid_changed()  # type: ignore
+
+    @property
+    def mac(self) -> str:
+        return "<unknown>" if self._mac is None else self._mac
+
+    @mac.setter
+    def mac(self, value: str):
+        if self._mac is None or self._mac != value:
+            self.logger.info(f"MAC addr: {self._mac}")
+            self._mac = value
+            self.mac_changed()  # type: ignore
+
+    @property
+    def sid(self) -> int:
+        return self._sid
+
+    @sid.setter
+    def sid(self, value: int):
+        if self._sid != value:
+            self.logger.info(f"Sensor ID: {self._sid}")
+            self._sid = value
+            self.sid_changed()  # type: ignore

--- a/processor/gen_record.py
+++ b/processor/gen_record.py
@@ -26,8 +26,8 @@ class GenRecord:
     @mac.setter
     def mac(self, value: str):
         if self._mac is None or self._mac != value:
-            self.logger.info(f"MAC addr: {self._mac}")
             self._mac = value
+            self.logger.info(f"MAC addr: {self._mac}")
             self.mac_changed()
 
     @property
@@ -40,8 +40,8 @@ class GenRecord:
     @sid.setter
     def sid(self, value: int):
         if self._sid != value:
-            self.logger.info(f"Sensor ID: {self._sid:X}")
             self._sid = value
+            self.logger.info(f"Sensor ID: {self._sid:X}")
             self.sid_changed()
 
     @property
@@ -80,8 +80,8 @@ class GenRecord:
     @title.setter
     def title(self, value: str):
         if self._nurse_name is None or self._nurse_name != value:
-            self.logger.info(f"Changed title to {value!r}")
             self._nurse_name = value
+            self.logger.info(f"Changed title to {self._nurse_name!r}")
             self.title_changed()
 
     def title_changed(self) -> None:

--- a/processor/gen_record.py
+++ b/processor/gen_record.py
@@ -13,15 +13,13 @@ class GenRecord:
     _mac: Optional[str] = None
     _sid: int = 0
 
-    _nurse_name: Optional[str] = None
-    _nurse_id: Optional[str] = None
+    _nurse_name: str = ""
 
     log: str = ""
 
     # Change these to add your own callbacks
     # These *only* run if you set a new value or the first time you set the value!
     title_changed: Callable[[], None] = lambda: None
-    nid_changed: Callable[[], None] = lambda: None
     sid_changed: Callable[[], None] = lambda: None
     mac_changed: Callable[[], None] = lambda: None
 
@@ -39,10 +37,7 @@ class GenRecord:
         """
         The title to show in the dialog box. Will show box_name if unset.
         """
-        if self._nurse_name is None:
-            return self.box_name
-        else:
-            return self._nurse_name
+        return self._nurse_name
 
     @title.setter
     def title(self, value: str):
@@ -53,14 +48,12 @@ class GenRecord:
 
     @property
     def nurse_id(self) -> str:
-        return "?" if self._nurse_id is None else self._nurse_id
-
-    @nurse_id.setter
-    def nurse_id(self, value: str):
-        if self._nurse_id is None or self._nurse_id != value:
-            self.logger.info(f"Changed short name to {self._nurse_id!r}")
-            self._nurse_id = value
-            self.nid_changed()  # type: ignore
+        if self._nurse_name:
+            return self._nurse_name[:4]
+        elif self.mac is not None:
+            return "".join(name[:2] for name in self.box_name.split())
+        else:
+            return "?"
 
     @property
     def mac(self) -> str:
@@ -80,6 +73,6 @@ class GenRecord:
     @sid.setter
     def sid(self, value: int):
         if self._sid != value:
-            self.logger.info(f"Sensor ID: {self._sid}")
+            self.logger.info(f"Sensor ID: {self._sid:X}")
             self._sid = value
             self.sid_changed()  # type: ignore

--- a/processor/gen_record.py
+++ b/processor/gen_record.py
@@ -18,6 +18,9 @@ class GenRecord:
 
     @property
     def mac(self) -> str:
+        """
+        The mac address. Returns <unknown> if the address is not known.
+        """
         return "<unknown>" if self._mac is None else self._mac
 
     @mac.setter
@@ -25,9 +28,13 @@ class GenRecord:
         if self._mac is None or self._mac != value:
             self.logger.info(f"MAC addr: {self._mac}")
             self._mac = value
+            self.mac_changed()
 
     @property
     def sid(self) -> int:
+        """
+        Sensor ID, as an integer. Printout with "X" format.
+        """
         return self._sid
 
     @sid.setter
@@ -35,13 +42,31 @@ class GenRecord:
         if self._sid != value:
             self.logger.info(f"Sensor ID: {self._sid:X}")
             self._sid = value
+            self.sid_changed()
 
     @property
     def box_name(self) -> str:
+        """
+        The name of the box, or <unknown>.
+        """
         if self.mac is None:
             return "<unknown>"
         try:
             return address_to_name(self.mac).title()
+        except ValueError:
+            return self.mac
+
+    @property
+    def stacked_name(self) -> str:
+        """
+        Return the box name stacked using a newline
+        If unknown, return Box name: <unknown>.
+        """
+
+        if self.mac is None:
+            return "Box name:\n<unknown>"
+        try:
+            return "\n".join(address_to_name(self.mac).title().split())
         except ValueError:
             return self.mac
 
@@ -60,6 +85,16 @@ class GenRecord:
             self.title_changed()
 
     def title_changed(self) -> None:
+        """
+        Modify in subclasses to add special callbacks here.
+        """
+
+    def mac_changed(self) -> None:
+        """
+        Modify in subclasses to add special callbacks here.
+        """
+
+    def sid_changed(self) -> None:
         """
         Modify in subclasses to add special callbacks here.
         """

--- a/processor/gen_record.py
+++ b/processor/gen_record.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Optional
+from dataclasses import dataclass
+from logging import Logger
+from processor.device_names import address_to_name
+
+
+@dataclass
+class GenRecord:
+    logger: Logger
+
+    mac: Optional[str] = None
+    _nurse_name: Optional[str] = None
+    _nurse_id: Optional[str] = None
+    log: str = ""
+
+    @property
+    def name(self) -> str:
+        if self._nurse_name is None:
+            return self.box_name
+        else:
+            return self._nurse_name
+
+    @name.setter
+    def name(self, value: str):
+        self._nurse_name = value
+
+    @property
+    def box_name(self):
+        return "<unknown>" if self.mac is None else address_to_name(self.mac).title()
+
+    @property
+    def nurse_id(self) -> str:
+        return "?" if self._nurse_id is None else self._nurse_id

--- a/processor/gen_record.py
+++ b/processor/gen_record.py
@@ -13,15 +13,28 @@ class GenRecord:
     _mac: Optional[str] = None
     _sid: int = 0
 
+    # Nurse only, but in master class to make simpler
     _nurse_name: str = ""
 
-    log: str = ""
+    @property
+    def mac(self) -> str:
+        return "<unknown>" if self._mac is None else self._mac
 
-    # Change these to add your own callbacks
-    # These *only* run if you set a new value or the first time you set the value!
-    title_changed: Callable[[], None] = lambda: None
-    sid_changed: Callable[[], None] = lambda: None
-    mac_changed: Callable[[], None] = lambda: None
+    @mac.setter
+    def mac(self, value: str):
+        if self._mac is None or self._mac != value:
+            self.logger.info(f"MAC addr: {self._mac}")
+            self._mac = value
+
+    @property
+    def sid(self) -> int:
+        return self._sid
+
+    @sid.setter
+    def sid(self, value: int):
+        if self._sid != value:
+            self.logger.info(f"Sensor ID: {self._sid:X}")
+            self._sid = value
 
     @property
     def box_name(self) -> str:
@@ -44,35 +57,9 @@ class GenRecord:
         if self._nurse_name is None or self._nurse_name != value:
             self.logger.info(f"Changed title to {value!r}")
             self._nurse_name = value
-            self.title_changed()  # type: ignore
+            self.title_changed()
 
-    @property
-    def nurse_id(self) -> str:
-        if self._nurse_name:
-            return self._nurse_name[:4]
-        elif self.mac is not None:
-            return "".join(name[:2] for name in self.box_name.split())
-        else:
-            return "?"
-
-    @property
-    def mac(self) -> str:
-        return "<unknown>" if self._mac is None else self._mac
-
-    @mac.setter
-    def mac(self, value: str):
-        if self._mac is None or self._mac != value:
-            self.logger.info(f"MAC addr: {self._mac}")
-            self._mac = value
-            self.mac_changed()  # type: ignore
-
-    @property
-    def sid(self) -> int:
-        return self._sid
-
-    @sid.setter
-    def sid(self, value: int):
-        if self._sid != value:
-            self.logger.info(f"Sensor ID: {self._sid:X}")
-            self._sid = value
-            self.sid_changed()  # type: ignore
+    def title_changed(self) -> None:
+        """
+        Modify in subclasses to add special callbacks here.
+        """

--- a/processor/generator.py
+++ b/processor/generator.py
@@ -44,6 +44,7 @@ class Generator(abc.ABC):
         rotary: processor.rotary.LocalRotary = None,
         logger: logging.Logger = None,
         no_save: bool = False,
+        gen_record: GenRecord = None,
     ) -> None:
 
         # The size of the rolling window
@@ -150,7 +151,7 @@ class Generator(abc.ABC):
         self.logger: logging.Logger = logger or logging.getLogger("povm")
 
         # Used by GUI to bundle information
-        self.record = GenRecord(self.logger)
+        self.record = GenRecord(self.logger) if gen_record is None else gen_record
 
         # Saver instances
         self.saver_ts: Optional[CSVSaverTS] = None

--- a/processor/generator.py
+++ b/processor/generator.py
@@ -276,14 +276,6 @@ class Generator(abc.ABC):
         Copy in the remote/local datastream to internal cache.
         """
 
-    @property
-    def sensor_id(self) -> int:
-        """
-        Get the sensor ID set on the device
-        """
-
-        return int(self.rotary["Sensor ID"].value)
-
     def _analyze_timeseries(self) -> None:
         """
         Quick analysis that's easier to run often, makes volume (run by `analyze` too)

--- a/processor/generator.py
+++ b/processor/generator.py
@@ -142,12 +142,6 @@ class Generator(abc.ABC):
         # A quick way to get the debug status
         self._debug = config["global"]["debug"].get(bool)
 
-        # The mac address if known
-        self.mac = ""
-
-        # The Sensor ID if known (0 otherwise)
-        self.sid = 0
-
         # An incrementing unique ID (for logging, perhaps)
         self.gen_id: Final[int] = self._total_generators
         self._total_generators += 1

--- a/processor/listener.py
+++ b/processor/listener.py
@@ -7,7 +7,6 @@ import queue
 import logging
 import ipaddress
 from typing import Set, Callable
-from processor.argparse import init_logger
 from dataclasses import dataclass
 
 logger = logging.getLogger("povm")
@@ -110,8 +109,6 @@ class FindBroadcasts:
 
 
 if __name__ == "__main__":
-    # init_logger()
-
     fb = FindBroadcasts()
 
     def proc():

--- a/processor/listener.py
+++ b/processor/listener.py
@@ -8,6 +8,7 @@ import logging
 import ipaddress
 from typing import Set, Callable
 from dataclasses import dataclass
+from processor.device_names import address_to_name
 
 logger = logging.getLogger("povm")
 
@@ -23,8 +24,15 @@ class Detector:
     def url(self):
         return f"tcp://{ipaddress.ip_address(self.address)}:{self.port}"
 
+    @property
+    def name(self) -> str:
+        try:
+            return address_to_name(self.mac)
+        except ValueError:
+            return self.mac
+
     def __str__(self):
-        return f"{self.mac} @ {ipaddress.ip_address(self.address)}:{self.port}"
+        return f"{self.name} @ {ipaddress.ip_address(self.address)}:{self.port}"
 
     def __hash__(self):
         return hash((self.address, self.port))

--- a/processor/local_generator.py
+++ b/processor/local_generator.py
@@ -6,11 +6,12 @@ import logging
 from sim.start_sims import start_sims
 from processor.rolling import new_elements
 from processor.generator import Generator, Status
+from processor.gen_record import GenRecord
 
 
 class LocalGenerator(Generator):
-    def __init__(self, *, i: int, logger: logging.Logger):
-        super().__init__(logger=logger)
+    def __init__(self, *, i: int, logger: logging.Logger, gen_record: GenRecord = None):
+        super().__init__(logger=logger, gen_record=gen_record)
         self.status = Status.OK
 
         self.record.mac = f"dc:a6:32:00:00:{i:02x}"

--- a/processor/local_generator.py
+++ b/processor/local_generator.py
@@ -13,6 +13,8 @@ class LocalGenerator(Generator):
         super().__init__(logger=logger)
         self.status = Status.OK
 
+        self.record.mac = f"dc:a6:32:00:00:{i:02x}"
+
         self._start_time = int(1000 * time.monotonic())
         (self._sim,) = start_sims(1, self._start_time, 12000000)
 

--- a/processor/local_generator.py
+++ b/processor/local_generator.py
@@ -4,14 +4,13 @@ import numpy as np
 import logging
 
 from sim.start_sims import start_sims
-from processor.rolling import Rolling, new_elements
+from processor.rolling import new_elements
 from processor.generator import Generator, Status
 
 
 class LocalGenerator(Generator):
     def __init__(self, *, i: int, logger: logging.Logger):
         super().__init__(logger=logger)
-        self.rotary["Sensor ID"].value = i
         self.status = Status.OK
 
         self._start_time = int(1000 * time.monotonic())

--- a/processor/remote_generator.py
+++ b/processor/remote_generator.py
@@ -31,7 +31,7 @@ class RemoteThread(threading.Thread):
         self._last_update: Optional[datetime] = None
         self._last_get: Optional[float] = None
         self.rotary_dict: Dict[str, Dict[str, float]] = {}
-        self.mac = ""
+        self.mac: Optional[str] = None
         self.sid = 0
 
         super().__init__()
@@ -94,7 +94,8 @@ class RemoteThread(threading.Thread):
                 self.parent.status = Status.OK
 
             # These log and perform (simple, please!) callbacks
-            self.parent.record.mac = self.mac
+            if self.mac is not None:
+                self.parent.record.mac = self.mac
             self.parent.record.sid = self.sid
 
             if len(self._time) > 0:

--- a/processor/remote_generator.py
+++ b/processor/remote_generator.py
@@ -14,6 +14,7 @@ import logging
 
 from processor.rolling import Rolling, new_elements
 from processor.generator import Status, Generator
+from processor.gen_record import GenRecord
 
 
 class RemoteThread(threading.Thread):
@@ -108,9 +109,13 @@ class RemoteThread(threading.Thread):
 
 class RemoteGenerator(Generator):
     def __init__(
-        self, *, address: str = "tcp://127.0.0.1:8100", logger: logging.Logger
+        self,
+        *,
+        address: str = "tcp://127.0.0.1:8100",
+        logger: logging.Logger,
+        gen_record: GenRecord = None,
     ):
-        super().__init__(logger=logger)
+        super().__init__(logger=logger, gen_record=gen_record)
         self._address = address
 
         self.status = Status.DISCON

--- a/processor/remote_generator.py
+++ b/processor/remote_generator.py
@@ -92,13 +92,9 @@ class RemoteThread(threading.Thread):
             elif self.parent.status == Status.DISCON:
                 self.parent.status = Status.OK
 
-            if self.parent.mac != self.mac:
-                self.parent.mac = self.mac
-                self.parent.logger.info(f"Mac Address: {self.mac}")
-
-            if self.parent.sid != self.sid:
-                self.parent.sid = self.sid
-                self.parent.logger.info(f"Sensor ID: {self.sid}")
+            # These log and perform (simple, please!) callbacks
+            self.parent.record.mac = self.mac
+            self.parent.record.sid = self.sid
 
             if len(self._time) > 0:
                 self.parent._last_ts = self._time[-1]

--- a/processor/remote_generator.py
+++ b/processor/remote_generator.py
@@ -138,7 +138,6 @@ class RemoteGenerator(Generator):
     ):
         super().__init__(logger=logger)
         self._address = address
-        self.rotary["Sensor ID"].value = 0
 
         self.status = Status.DISCON
         self._last_ts: int = 0

--- a/processor/setting.py
+++ b/processor/setting.py
@@ -8,6 +8,8 @@ Number = Union[float, int]
 
 
 class Setting(abc.ABC):
+    STATIC_UPPER = True
+
     def __init__(
         self,
         *,
@@ -19,9 +21,6 @@ class Setting(abc.ABC):
     ):
         self._name = name
         self._lcd_name: Optional[str] = lcd_name or name
-        assert (
-            len(self.lcd_name) <= 16
-        ), f"Length of LCD names must be less than 16 chars: {self.lcd_name!r}"
         self.unit = unit
         self._lock = threading.Lock()
         self._value: Any = None
@@ -186,16 +185,16 @@ class SelectionSetting(Setting):
         rate: int = 2,
     ):
 
-        super().__init__(unit=unit, name=name, lcd_name=lcd_name, zero=zero, rate=rate)
-
         assert (
             0 <= default < len(listing)
         ), "Default must be an index into the list given"
 
-        self._value = default
-        self._original_value = default
-        self._listing = listing
-        self._zero = zero
+        super().__init__(unit=unit, name=name, lcd_name=lcd_name, zero=zero, rate=rate)
+
+        self._value: int = default
+        self._original_value: int = default
+        self._listing: List[Any] = listing
+        self._zero: Optional[str] = zero
 
     def _up_(self) -> None:
         "Return true if not at limit"

--- a/processor/setting.py
+++ b/processor/setting.py
@@ -114,18 +114,12 @@ class Setting(abc.ABC):
 
 class DisplaySetting(Setting):
     def __init__(
-        self,
-        value: Any,
-        *,
-        name: str,
-        unit: str = None,
-        lcd_name: str = None,
-        rate: int = 1,
+        self, *, name: str, unit: str = None, lcd_name: str = None, rate: int = 1,
     ):
         super().__init__(unit=unit, name=name, lcd_name=lcd_name, rate=rate)
 
-        self._value = value
-        self._original_value = value
+        self._value = ""
+        self._original_value = ""
 
     def _up_(self) -> None:
         pass

--- a/processor/setting.py
+++ b/processor/setting.py
@@ -114,7 +114,7 @@ class Setting(abc.ABC):
 
 class DisplaySetting(Setting):
     def __init__(
-        self, *, name: str, unit: str = None, lcd_name: str = None, rate: int = 1,
+        self, name: str, *, unit: str = None, lcd_name: str = None, rate: int = 1,
     ):
         super().__init__(unit=unit, name=name, lcd_name=lcd_name, rate=rate)
 
@@ -125,6 +125,14 @@ class DisplaySetting(Setting):
         pass
 
     def _down_(self) -> None:
+        pass
+
+    @property
+    def default(self) -> float:
+        return 0.0
+
+    @default.setter
+    def default(self, val: float):
         pass
 
 

--- a/processor/setting.py
+++ b/processor/setting.py
@@ -111,30 +111,6 @@ class Setting(abc.ABC):
         """
 
 
-class DisplaySetting(Setting):
-    def __init__(
-        self, name: str, *, unit: str = None, lcd_name: str = None, rate: int = 1,
-    ):
-        super().__init__(unit=unit, name=name, lcd_name=lcd_name, rate=rate)
-
-        self._value = ""
-        self._original_value = ""
-
-    def _up_(self) -> None:
-        pass
-
-    def _down_(self) -> None:
-        pass
-
-    @property
-    def default(self) -> float:
-        return 0.0
-
-    @default.setter
-    def default(self, val: float):
-        pass
-
-
 class IncrSetting(Setting):
     def __init__(
         self,

--- a/processor/settings.py
+++ b/processor/settings.py
@@ -7,6 +7,7 @@ from processor.display_settings import (
     CurrentSetting,
     ResetSetting,
     NameSetting,
+    MACSetting,
 )
 from processor.config import config
 
@@ -67,6 +68,8 @@ def get_setting(c: ConfigView) -> Tuple[Optional[int], Setting]:
         return order, FilenameSetting("Log filename")
     elif type_name == "Name":
         return order, NameSetting(c["name"].get())
+    elif type_name == "MAC":
+        return order, MACSetting(c["name"].get())
     else:
         raise RuntimeError(
             f"Invalid type {type_name!r}, needs to be defined in setting.py/settings.py"

--- a/processor/settings.py
+++ b/processor/settings.py
@@ -3,11 +3,9 @@ from __future__ import annotations
 
 from processor.setting import IncrSetting, SelectionSetting, Setting
 from processor.display_settings import (
-    FilenameSetting,
+    AdvancedSetting,
     CurrentSetting,
     ResetSetting,
-    NameSetting,
-    MACSetting,
 )
 from processor.config import config
 
@@ -64,12 +62,8 @@ def get_setting(c: ConfigView) -> Tuple[Optional[int], Setting]:
                 name=c["name"].get(), rate=c["rate"].get(int) if "rate" in c else 1,
             ),
         )
-    elif type_name == "Filename":
-        return order, FilenameSetting("Log filename")
-    elif type_name == "Name":
-        return order, NameSetting(c["name"].get())
-    elif type_name == "MAC":
-        return order, MACSetting(c["name"].get())
+    elif type_name == "Advanced":
+        return order, AdvancedSetting(rate=c["rate"].get(int) if "rate" in c else 2)
     else:
         raise RuntimeError(
             f"Invalid type {type_name!r}, needs to be defined in setting.py/settings.py"

--- a/processor/settings.py
+++ b/processor/settings.py
@@ -82,7 +82,7 @@ def reorder(indict: Dict[str, Setting], ordering: Dict[str, int]) -> Dict[str, S
     # Values that have a positive order go first (0, then 1, etc.)
     for value in above_values:
         keys = {k for k, v in ordering.items() if v == value}
-        master.update({k: v for k, v in indict.items() if k not in keys})
+        master.update({k: v for k, v in indict.items() if k in keys})
 
     # Values that have no order go in the middle
     master.update({k: v for k, v in indict.items() if k not in ordering})
@@ -90,7 +90,7 @@ def reorder(indict: Dict[str, Setting], ordering: Dict[str, int]) -> Dict[str, S
     # Values with a negative order go at the end (-3, -2, -1)
     for value in below_values:
         keys = {k for k, v in ordering.items() if v == value}
-        master.update({k: v for k, v in indict.items() if k not in keys})
+        master.update({k: v for k, v in indict.items() if k in keys})
 
     return master
 

--- a/processor/settings.py
+++ b/processor/settings.py
@@ -1,76 +1,127 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 
 from processor.setting import IncrSetting, SelectionSetting, Setting
-from processor.display_settings import FilenameSetting, CurrentSetting, ResetSetting
+from processor.display_settings import (
+    FilenameSetting,
+    CurrentSetting,
+    ResetSetting,
+    NameSetting,
+)
 from processor.config import config
 
-from typing import Dict
+from typing import Dict, Tuple, Optional
 from confuse import ConfigView
 from pprint import pprint
 
 
-def get_setting(c: ConfigView) -> Setting:
+def get_setting(c: ConfigView) -> Tuple[Optional[int], Setting]:
     type_name = c["type"].get()
+    order = c["order"].get(int) if "order" in c else None
     if type_name == "Incr":
-        return IncrSetting(
-            default=c["default"].as_number(),
-            min=c["min"].as_number(),
-            max=c["max"].as_number(),
-            incr=c["incr"].as_number(),
-            name=c["name"].get(),
-            unit=c["unit"].get() if "unit" in c else None,
-            rate=c["rate"].get(int) if "rate" in c else 1,
-            zero=c["zero"].get() if "zero" in c else None,
-            lcd_name=c["lcd_name"].get() if "lcd_name" in c else None,
+        return (
+            order,
+            IncrSetting(
+                default=c["default"].as_number(),
+                min=c["min"].as_number(),
+                max=c["max"].as_number(),
+                incr=c["incr"].as_number(),
+                name=c["name"].get(),
+                unit=c["unit"].get() if "unit" in c else None,
+                rate=c["rate"].get(int) if "rate" in c else 1,
+                zero=c["zero"].get() if "zero" in c else None,
+                lcd_name=c["lcd_name"].get() if "lcd_name" in c else None,
+            ),
         )
     elif type_name == "Selection":
-        return SelectionSetting(
-            default=c["default"].get(int),
-            listing=[v.as_number() for v in c["items"]],
-            name=c["name"].get(),
-            unit=c["unit"].get() if "unit" in c else None,
-            zero=c["zero"].get() if "zero" in c else None,
-            rate=c["rate"].get(int) if "rate" in c else 2,
-            lcd_name=c["lcd_name"].get() if "lcd_name" in c else None,
+        return (
+            order,
+            SelectionSetting(
+                default=c["default"].get(int),
+                listing=[v.as_number() for v in c["items"]],
+                name=c["name"].get(),
+                unit=c["unit"].get() if "unit" in c else None,
+                zero=c["zero"].get() if "zero" in c else None,
+                rate=c["rate"].get(int) if "rate" in c else 2,
+                lcd_name=c["lcd_name"].get() if "lcd_name" in c else None,
+            ),
         )
     elif type_name == "Current":
-        return CurrentSetting(
-            default=c["default"].get(int),
-            listing=[v.as_number() for v in c["items"]],
-            rate=c["rate"].get(int) if "rate" in c else 2,
-            name="Current:",
+        return (
+            order,
+            CurrentSetting(
+                default=c["default"].get(int),
+                listing=[v.as_number() for v in c["items"]],
+                rate=c["rate"].get(int) if "rate" in c else 2,
+                name="Current:",
+            ),
         )
     elif type_name == "Reset":
-        return ResetSetting(
-            name=c["name"].get(), rate=c["rate"].get(int) if "rate" in c else 1,
+        return (
+            order,
+            ResetSetting(
+                name=c["name"].get(), rate=c["rate"].get(int) if "rate" in c else 1,
+            ),
         )
     elif type_name == "Filename":
-        return FilenameSetting("Log filename")
+        return order, FilenameSetting("Log filename")
+    elif type_name == "Name":
+        return order, NameSetting(c["name"].get())
     else:
         raise RuntimeError(
             f"Invalid type {type_name!r}, needs to be defined in setting.py/settings.py"
         )
 
 
+def reorder(indict: Dict[str, Setting], ordering: Dict[str, int]) -> Dict[str, Setting]:
+    master: Dict[str, Setting] = {}
+
+    above_values = sorted(v for v in set(ordering.values()) if v >= 0)
+    below_values = sorted(v for v in set(ordering.values()) if v < 0)
+
+    # Values that have a positive order go first (0, then 1, etc.)
+    for value in above_values:
+        keys = {k for k, v in ordering.items() if v == value}
+        master.update({k: v for k, v in indict.items() if k not in keys})
+
+    # Values that have no order go in the middle
+    master.update({k: v for k, v in indict.items() if k not in ordering})
+
+    # Values with a negative order go at the end (-3, -2, -1)
+    for value in below_values:
+        keys = {k for k, v in ordering.items() if v == value}
+        master.update({k: v for k, v in indict.items() if k not in keys})
+
+    return master
+
+
 def get_live_settings() -> Dict[str, Setting]:
     "Get the live version of the configuration dictionary"
 
     d: Dict[str, Setting] = {}
+    ordering: Dict[str, int] = {}
     all_settings = [config["rotary-live"], config["rotary"]]
     for settings in all_settings:
         for setting in settings:
-            d[setting] = get_setting(settings[setting])
-    return d
+            order, d[setting] = get_setting(settings[setting])
+            if order is not None:
+                ordering[setting] = order
+
+    return reorder(d, ordering)
 
 
 def get_remote_settings() -> Dict[str, Setting]:
     "Get the non-live version of the configuration dictionary"
     d: Dict[str, Setting] = {}
+    ordering: Dict[str, int] = {}
     all_settings = [config["rotary"]]
     for settings in all_settings:
         for setting in settings:
-            d[setting] = get_setting(settings[setting])
-    return d
+            order, d[setting] = get_setting(settings[setting])
+            if order is not None:
+                ordering[setting] = order
+
+    return reorder(d, ordering)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The boxes now display their names on startup and as a menu item. The MAC addr is still there, just as a menu item. Menu items are numbered to make it easier to navigate.

* Advanced menu for display items, version, Sensor ID
* Better activate for resettable menus (Reset, Advanced)
* Fixed several LCD update issues, much smoother changing - only "Current" auto-updates
* Starting help screen, color coded startup
* New syncing system, nothing to set, name shows up in many places
* Allow negative minimum pressure
* Turn off RR by turning to 0
* PushTurn text added
* Title changes stored in log (MAC and sensor ID changes too)