### PR TITLE
Selectable directory

### DIFF
--- a/config/patientdevice.service
+++ b/config/patientdevice.service
@@ -5,7 +5,7 @@ After=pigpiod.service
 [Service]
 Type=simple
 User=pi
-ExecStart= /usr/bin/python3 /home/pi/princeton-penn-flowmeter/device_loop.py --file /home/pi/princeton-penn-flowmeter/device_log/data.out
+ExecStart= /usr/bin/python3 /home/pi/princeton-penn-flowmeter/device_loop.py --dir /data
 WorkingDirectory=/home/pi/princeton-penn-flowmeter
 Restart=always
 

--- a/config/patientloop.service
+++ b/config/patientloop.service
@@ -5,7 +5,7 @@ After=patientdevice.service
 [Service]
 Type=simple
 User=pi
-ExecStart= /usr/bin/python3 /home/pi/princeton-penn-flowmeter/patient_loop.py
+ExecStart= /usr/bin/python3 /home/pi/princeton-penn-flowmeter/patient_loop.py --dir /data
 WorkingDirectory=/home/pi/princeton-penn-flowmeter
 Restart=always
 

--- a/device_loop.py
+++ b/device_loop.py
@@ -5,10 +5,14 @@ import argparse
 
 parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 parser.add_argument("--name", default="data.out", help="Base filename to record to")
+parser.add_argument("--file", help="DEPRECATED: do no use")
 parser.add_argument(
     "--dir", help="Directory to record to (device_log will be appended)"
 )
 arg = parser.parse_args()
+
+if arg.file:
+    print("Warning: Do not use --file, use --dir and/or --name instead")
 
 # hardware interfaces:
 # SDP3 diff pressure sensor - I2C handled by pigpio.pi()
@@ -257,7 +261,7 @@ with ExitStack() as stack:
 
     myfile = None  # type: Optional[TextIO]
 
-    if arg.file:
+    if arg.name:
         file_path = directory / arg.name
         myfile = stack.enter_context(open_next(file_path))
         print("Logging:", myfile.name)

--- a/device_loop.py
+++ b/device_loop.py
@@ -39,7 +39,9 @@ if arg.dir:
 else:
     directory = DIR / "device_log"
 
-directory.mkdir(parents=True, exist_ok=True)
+if arg.name:
+    print("Logging to", directory)
+    directory.mkdir(parents=True, exist_ok=True)
 
 ReadoutHz: "Final" = 50.0
 oversampleADC: "Final" = 4

--- a/nurse/common.py
+++ b/nurse/common.py
@@ -6,7 +6,7 @@ from nurse.qt import QtGui
 from processor.config import get_internal_file
 
 style_path = get_internal_file("nurse/style.css")
-dialog_style_path = get_internal_file("dialogs.css")
+dialog_style_path = get_internal_file("nurse/dialogs.css")
 
 guicolors = {
     "ALERT": QtGui.QColor(0, 0, 100),

--- a/nurse/common.py
+++ b/nurse/common.py
@@ -3,9 +3,10 @@ from pathlib import Path
 from nurse.qt import QtGui
 
 # Replace with proper importlib.resources if made a package
-DIR = Path(__file__).parent.absolute()
-style_path = DIR / "style.css"
-dialog_style_path = DIR / "dialogs.css"
+from processor.config import get_internal_file
+
+style_path = get_internal_file("nurse/style.css")
+dialog_style_path = get_internal_file("dialogs.css")
 
 guicolors = {
     "ALERT": QtGui.QColor(0, 0, 100),

--- a/nurse/drilldown.py
+++ b/nurse/drilldown.py
@@ -517,7 +517,7 @@ class PatientDrilldownWidget(QtWidgets.QFrame):
 
     @Slot()
     def external_update_sid(self):
-        text = f"Sensor ID: {self.gen.record.sid:X}"
+        text = f"Sensor ID: {self.gen.record.sid:016X}"
         if self.sensor_id.text() != text:
             self.sensor_id.setText(text)
 

--- a/nurse/generator_dialog.py
+++ b/nurse/generator_dialog.py
@@ -33,7 +33,7 @@ class DetailsTab(QtWidgets.QWidget):
         layout = QtWidgets.QFormLayout(self)
 
         layout.addRow("MAC Addr:", QtWidgets.QLabel(gen.record.mac))
-        layout.addRow("Sensor:", QtWidgets.QLabel(format(gen.record.sid, "X")))
+        layout.addRow("Sensor:", QtWidgets.QLabel(format(gen.record.sid, "016X")))
         layout.addRow(
             "IP Address:", QtWidgets.QLabel(getattr(gen, "address", "Simulation"))
         )

--- a/nurse/help_dialog.py
+++ b/nurse/help_dialog.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 from nurse.qt import QtWidgets, QtGui, QtCore, Qt, Slot, HBoxLayout
+from processor.version import get_version
 
 
 class HelpDialog(QtWidgets.QDialog):
@@ -40,6 +41,9 @@ class HelpDialog(QtWidgets.QDialog):
         )
         drilldown_help.setWordWrap(True)
         tabs.addTab(drilldown_help, "Drilldown")
+
+        version = get_version() or "<unknown>"
+        layout.addWidget(QtWidgets.QLabel(f"Version: {version}"))
 
         self.button = QtWidgets.QDialogButtonBox(QtWidgets.QDialogButtonBox.Ok)
         layout.addWidget(self.button)

--- a/nursegui.py
+++ b/nursegui.py
@@ -6,13 +6,11 @@ import pyqtgraph as pg
 import sys
 import math
 from string import Template
-from pathlib import Path
 import signal
 import logging
 from typing import Optional, List, Tuple
 import threading
 import itertools
-from collections import Counter
 
 from nurse.qt import (
     QtCore,
@@ -37,8 +35,6 @@ from nurse.gen_record_gui import GenRecordGUI
 from processor.argparse import ArgumentParser
 from processor.listener import FindBroadcasts
 from processor.logging import make_nested_logger
-
-DIR = Path(__file__).parent.resolve()
 
 logger = logging.getLogger("povm")
 

--- a/patient_loop.py
+++ b/patient_loop.py
@@ -9,7 +9,6 @@ args = parser.parse_args()
 
 import signal
 import threading
-from pathlib import Path
 from contextlib import ExitStack
 
 
@@ -18,8 +17,7 @@ from patient.rotary_lcd import RotaryLCD
 from processor.collector import Collector
 from processor.broadcast import Broadcast
 from patient.mac_address import get_box_name
-
-DIR = Path(__file__).parent.resolve()
+from processor.config import get_data_dir
 
 
 # Initialize LCD
@@ -50,8 +48,8 @@ with ExitStack() as stack:
     collector = stack.enter_context(Collector(rotary=rotary, port=args.port))
     stack.enter_context(Broadcast("patient_loop", port=args.port, live=5))
 
-    rotary.live_load(DIR / "povm-live.yml")
-    rotary.live_save(DIR / "povm-live.yml", every=10)
+    rotary.live_load(get_data_dir() / "povm-live.yml")
+    rotary.live_save(get_data_dir() / "povm-live.yml", every=10)
 
     signal.signal(signal.SIGINT, close)
     signal.signal(signal.SIGTERM, close)

--- a/patientgui.py
+++ b/patientgui.py
@@ -8,22 +8,21 @@ args = parser.parse_args()
 
 import sys
 import signal
-from pathlib import Path
 
 from nurse.qt import QtWidgets
 from processor.settings import get_live_settings
 from patient.rotary_gui import MainWindow, RotaryGUI
 from processor.collector import Collector
 from processor.broadcast import Broadcast
+from processor.config import get_data_dir
 
-DIR = Path(__file__).parent.resolve()
 
 with RotaryGUI(get_live_settings()) as rotary, Collector(
     rotary=rotary, port=args.port
 ) as collector, Broadcast("patientgui", port=args.port, live=5):
 
-    rotary.live_load(DIR / "povm-live.yml")
-    rotary.live_save(DIR / "povm-live.yml", every=10)
+    rotary.live_load(get_data_dir() / "povm-live.yml")
+    rotary.live_save(get_data_dir() / "povm-live.yml", every=10)
 
     app = QtWidgets.QApplication([])
     main = MainWindow(rotary, collector)

--- a/processor/argparse.py
+++ b/processor/argparse.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
-from pathlib import Path
 import argparse
 from typing import Tuple, List, Optional
 
-from processor.config import config
+from processor.config import config, get_internal_file
 from processor.logging import init_logger
-
-
-DIR = Path(__file__).parent.resolve()
 
 
 class ArgumentParser(argparse.ArgumentParser):
@@ -19,7 +15,7 @@ class ArgumentParser(argparse.ArgumentParser):
 
         self.add_argument(
             "--config",
-            default=str(DIR.parent / "povm.yml"),
+            default=str(get_internal_file("processor/povm.yml")),
             help="YAML configuration file",
         )
 
@@ -28,6 +24,8 @@ class ArgumentParser(argparse.ArgumentParser):
             action="store_true",
             help="Start up in debug mode (log to screen)",
         )
+
+        self.add_argument("--dir", help="Set a directory to log data to")
 
         self.log_dir = log_dir
         self.log_stem = log_stem
@@ -42,6 +40,9 @@ class ArgumentParser(argparse.ArgumentParser):
 
         if args.config:
             config.set_file(args.config)
+
+        if "dir" in args:
+            config.set_args({"global": {"datadir": args.dir}})
 
         if "debug" in args:
             config.set_args({"global": {"debug": args.debug}})

--- a/processor/argparse.py
+++ b/processor/argparse.py
@@ -15,7 +15,7 @@ class ArgumentParser(argparse.ArgumentParser):
 
         self.add_argument(
             "--config",
-            default=str(get_internal_file("processor/povm.yml")),
+            default=str(get_internal_file("povm.yml")),
             help="YAML configuration file",
         )
 

--- a/processor/collector.py
+++ b/processor/collector.py
@@ -21,6 +21,7 @@ class CollectorThread(threading.Thread):
     def __init__(self, parent: Collector):
         self.parent = parent
         self._sn: Optional[int] = None
+        self._file: Optional[str] = None
 
         self._time = Rolling(window_size=parent.window_size, dtype=np.int64)
         self._flow = Rolling(window_size=parent.window_size)
@@ -72,6 +73,9 @@ class CollectorThread(threading.Thread):
                 if "sn" in j:
                     self._sn = j["sn"]
 
+                if "file" in j:
+                    self._file = j["file"]
+
                 with self._collector_lock:
                     self._time.inject_value(t)
                     self._flow.inject_value(f)
@@ -91,6 +95,12 @@ class CollectorThread(threading.Thread):
                         if "Advanced" in self.parent.rotary:
                             setting = self.parent.rotary["Advanced"]
                             setting.sid = self._sn
+
+                    if self._file is not None:
+                        extra_dict["file"] = self._file
+                        if "Advanced" in self.parent.rotary:
+                            setting = self.parent.rotary["Advanced"]
+                            setting.file = self._file
 
                     pub_socket.send_json(extra_dict)
 

--- a/processor/config.py
+++ b/processor/config.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 import confuse
 from pathlib import Path
+from functools import lru_cache
+from typing import Union
+import logging
+
+logger = logging.getLogger("povm")
 
 DIR = Path(__file__).parent.resolve()
 
@@ -13,3 +18,25 @@ config.clear()
 # Defaults stored here
 config_default = DIR / "config_default.yaml"
 config.set_file(config_default)
+
+
+def get_internal_file(filename: Union[Path, str]) -> Path:
+    # A bit of a hacky workaround until we have a proper package
+    return DIR.parent / filename
+
+
+@lru_cache(1)
+def get_data_dir() -> Path:
+    """
+    * relative path: relative to package
+    * Path with ~ is expanded
+    * Absolute paths supported
+    """
+    path = Path(config["global"]["datadir"].get()).expanduser()
+    path = path if path.is_absolute() else DIR.parent / path
+    if not path.exists():
+        path.mkdir(parents=True)
+        logger.info(f"Created directory: {path}")
+    else:
+        logger.info(f"Logging to directory: {path}")
+    return path

--- a/processor/config_default.yaml
+++ b/processor/config_default.yaml
@@ -13,6 +13,7 @@ global:
   cumulative-every: 10 # seconds
   run-every: 0.5 # seconds
   window-size: 1500 # 30 seconds @ 50 hertz
+  datadir: data # relative, with home, or absolute
 
 patient:
   buzzer-volume: 0 # max 255 (200 ideal)

--- a/processor/device_names.py
+++ b/processor/device_names.py
@@ -2,18 +2,17 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from processor.config import get_internal_file
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing_extensions import Final
 
-DIR = Path(__file__).parent.resolve()
 
 vendors = ["dc:a6:32:00:00:00"]  # only append to this list
 
-adjectives = [x.strip() for x in open(DIR.parent / "data/adjectives.txt")]
-nouns = [x.strip() for x in open(DIR.parent / "data/nouns.txt")]
+adjectives = [x.strip() for x in open(get_internal_file("data/adjectives.txt"))]
+nouns = [x.strip() for x in open(get_internal_file("data/nouns.txt"))]
 
 assert len(adjectives) == 4096
 assert len(nouns) == 4096

--- a/processor/display_settings.py
+++ b/processor/display_settings.py
@@ -2,6 +2,7 @@ from processor.setting import SelectionSetting
 from typing import Optional, List, Sequence
 from patient.mac_address import get_mac_addr
 from processor.device_names import address_to_name
+from pathlib import Path
 
 
 class AdvancedSetting(SelectionSetting):
@@ -30,10 +31,13 @@ class AdvancedSetting(SelectionSetting):
             except ValueError:
                 return "<Unknown>"
         elif self._value == 2:
-            return f"{self.sid:016X}"
+            if self.sid:
+                return f"{self.sid:016X}"
+            else:
+                return "No sensor detected"
         elif self._value == 3:
             if self.file:
-                return self.file[-20:]
+                return Path(self.file).name[-20:]
             else:
                 return "Not recording"
         elif self._value == 4:

--- a/processor/display_settings.py
+++ b/processor/display_settings.py
@@ -3,6 +3,7 @@ from typing import Optional, List, Sequence
 from patient.mac_address import get_mac_addr
 from processor.device_names import address_to_name
 from pathlib import Path
+from processor.version import get_version
 
 
 class AdvancedSetting(SelectionSetting):
@@ -41,7 +42,7 @@ class AdvancedSetting(SelectionSetting):
             else:
                 return "Not recording"
         elif self._value == 4:
-            return "Classic: v0.3+"
+            return get_version() or "Unable to retrieve"
         else:
             raise NotImplementedError("Setting must be in range 0-3")
 

--- a/processor/display_settings.py
+++ b/processor/display_settings.py
@@ -1,12 +1,7 @@
 from processor.setting import SelectionSetting
-from pathlib import Path
 from typing import Optional, List, Sequence
 from patient.mac_address import get_mac_addr
 from processor.device_names import address_to_name
-
-
-DIR = Path(__file__).parent.resolve()
-(DIR.parent / "device_log").mkdir(exist_ok=True)
 
 
 class AdvancedSetting(SelectionSetting):
@@ -18,6 +13,7 @@ class AdvancedSetting(SelectionSetting):
 
         # Sensor ID
         self.sid: int = 0
+        self.file: str = ""
 
         super().__init__(0, string_listing, name="Advanced", rate=rate)
 
@@ -34,11 +30,12 @@ class AdvancedSetting(SelectionSetting):
             except ValueError:
                 return "<Unknown>"
         elif self._value == 2:
-            return f"{self.sid:X}"
+            return f"{self.sid:016X}"
         elif self._value == 3:
-            files = sorted(Path(DIR.parent / "device_log").glob("*"))
-            string = str(files[-1].name) if files else "No file"
-            return string
+            if self.file:
+                return self.file[-20:]
+            else:
+                return "Not recording"
         elif self._value == 4:
             return "Classic: v0.3+"
         else:

--- a/processor/gen_record.py
+++ b/processor/gen_record.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Optional, Callable
+from typing import Optional
 from dataclasses import dataclass
 from logging import Logger
 from processor.device_names import address_to_name

--- a/processor/logging.py
+++ b/processor/logging.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TextIO, Optional
+from typing import Optional
 import logging
 
-from processor.config import config
-
-DIR = Path(__file__).parent.resolve()
+from processor.config import config, get_data_dir
 
 
 def open_next(mypath: Path) -> Path:
@@ -39,7 +37,7 @@ def init_logger(logstr: Optional[str] = None) -> None:
         ch.setFormatter(formatter)
         logger.addHandler(ch)
     else:
-        file_path = DIR.parent / logstr
+        file_path = get_data_dir() / logstr
         file_path.parent.mkdir(exist_ok=True)
         logfile_incr = open_next(file_path)
         fh = logging.FileHandler(str(logfile_incr))

--- a/processor/version.py
+++ b/processor/version.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+import subprocess
+
+DIR = Path(__file__).parent.resolve()
+
+
+@lru_cache(1)
+def get_version() -> str:
+    try:
+        return (
+            subprocess.check_output(["git", "describe"], cwd=DIR, text=True)
+            .strip()
+            .lstrip("v")
+        )
+    except subprocess.CalledProcessError:
+        return ""


### PR DESCRIPTION
This allows a selectable directory, such as `--dir /data`, and a selectable name, `--name data.out`. Logging is on by default, but can be disabled with `--name ""`. The default directory is the same as the git repo, but is set to `/data` in the provided config service files.

Using `--file` on `device_loop.py` prints a warning and has no effect.

The actual logging file is transmitted and read by the patient loop now, and is available for use by the nursegui too, just in case we want to sync recordings (not recorded anywhere nurse-side yet).

The version number now changes every git commit, and is of the form `<last tag>-<commits since last tag>-<commit hash>`.