### PR TITLE
Plot improvements 

### DIFF
--- a/nurse/drilldown.py
+++ b/nurse/drilldown.py
@@ -723,8 +723,20 @@ class PatientDrilldownWidget(QtWidgets.QFrame):
 
         # Phase plot
         self.phase_graph = phase_layout.addPlot(x=None, y=None, name="Phase")
-        self.phase = self.phase_graph.plot(
-            x=None, y=None, pen=pg.mkPen(color=(200, 200, 0))
+        self.phase_graph.setRange(
+            xRange=gis.yLims["pressure"], yRange=gis.yLims["volume"]
+        )
+        self.phases = list(
+            reversed(
+                [
+                    self.phase_graph.plot(
+                        x=None,
+                        y=None,
+                        pen=pg.mkPen(color=(i * 50, i * 50, i * 10), width=3),
+                    )
+                    for i in range(1, 6)
+                ]
+            )
         )
         self.phase_graph.setLabel("left", "Volume", units="mL")
         self.phase_graph.setLabel("bottom", "Pressure", units="cm H2O")
@@ -789,7 +801,9 @@ class PatientDrilldownWidget(QtWidgets.QFrame):
                                 [self.gen.average_pressure[avg_window]] * 2,
                             )
 
-                    self.phase.setData(self.gen.pressure, self.gen.volume)
+                    for i, phase in enumerate(self.phases):
+                        range = slice(-(i + 1) * 50 * 2 - 1, -i * 50 * 2)
+                        phase.setData(self.gen.pressure[range], self.gen.volume[range])
 
                     if self.status != self.gen.status:
                         self.status = self.gen.status

--- a/nurse/drilldown.py
+++ b/nurse/drilldown.py
@@ -698,7 +698,9 @@ class PatientDrilldownWidget(QtWidgets.QFrame):
                 clipToView=True,
             )
             graphs[key].invertX()
-            graphs[key].setRange(xRange=(30, 0))
+            graphs[key].setRange(
+                xRange=(28, 0)
+            )  # Actually shows a bit more that the range
             graphs[key].setLabel("left", gis.graph_names[key], gis.units[key])
             if j != len(gis.graph_labels):
                 graph_layout.nextRow()
@@ -752,10 +754,10 @@ class PatientDrilldownWidget(QtWidgets.QFrame):
                     avg_window = config["global"]["avg-window"].get(int)
 
                     for key in gis.graph_labels:
+                        yvalues = getattr(self.gen, key)[-30 * 50 :]
                         if scroll:
-                            self.curves[key].setData(
-                                self.gen.time, getattr(self.gen, key)
-                            )
+                            xvalues = self.gen.time[-30 * 50 :]
+                            self.curves[key].setData(xvalues, yvalues)
                             x, _y = self.curves2[key].getData()
                             if x is not None and len(x) > 0:
                                 self.curves2[key].setData(
@@ -764,19 +766,16 @@ class PatientDrilldownWidget(QtWidgets.QFrame):
                                 )
 
                         else:
-                            last = self.gen.realtime[-1]
-                            breakpt = np.searchsorted(
-                                self.gen.realtime, last - last % 30
-                            )
+                            xvalues = self.gen.realtime[-30 * 50 :]
+                            last = xvalues[-1]
+                            breakpt = np.searchsorted(xvalues, last - last % 30)
                             gap = 25
 
                             self.curves[key].setData(
-                                30 - (self.gen.realtime[breakpt:] % 30),
-                                getattr(self.gen, key)[breakpt:],
+                                30 - (xvalues[breakpt:] % 30), yvalues[breakpt:],
                             )
                             self.curves2[key].setData(
-                                30 - (self.gen.realtime[gap:breakpt] % 30),
-                                getattr(self.gen, key)[gap:breakpt],
+                                30 - (xvalues[gap:breakpt] % 30), yvalues[gap:breakpt],
                             )
 
                         val_key = f"Avg {key.capitalize()}"

--- a/nurse/grid.py
+++ b/nurse/grid.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import pyqtgraph as pg
+import numpy as np
 
 from datetime import datetime
 
 from typing import Dict, Any, Optional
-
 
 from nurse.qt import (
     QtWidgets,
@@ -226,10 +226,15 @@ class PatientSensor(DraggableSensor):
             # Fill in the data
             for key in gis.graph_labels:
                 if self.isVisible():
-                    select = self.gen.time < 15 if len(self.gen.time) else slice(None)
-                    self.curves[key].setData(
-                        self.gen.time[select], getattr(self.gen, key)[select]
+                    select = (
+                        slice(np.searchsorted(-self.gen.time, -15), None)
+                        if len(self.gen.time)
+                        else slice(None)
                     )
+                    xvalues = self.gen.time[select]
+                    yvalues = getattr(self.gen, key)[select]
+
+                    self.curves[key].setData(xvalues, yvalues)
                 else:
                     self.curves[key].setData(x=None, y=None)
 

--- a/processor/config_default.yaml
+++ b/processor/config_default.yaml
@@ -12,7 +12,7 @@ global:
   save-every: 20 # seconds
   cumulative-every: 10 # seconds
   run-every: 0.5 # seconds
-  window-size: 1500 # 30 seconds @ 50 hertz
+  window-size: 1600 # 30 seconds @ 50 hertz + 100 extra (2 seconds)
   datadir: . # relative, with home, or absolute
   avg-window: 10 # seconds (pick from limited list)
 

--- a/processor/generator.py
+++ b/processor/generator.py
@@ -330,7 +330,7 @@ class Generator(abc.ABC):
             #     self._volume_unshifted_min = min(
             #         self._volume_unshifted_min, np.min(self._volume)
             #     )
-            self._volume_unshifted_min = np.min(self._volume)
+            self._volume_unshifted_min = np.min(self._volume[-25 * 50 :])
             #
             # END
 

--- a/processor/generator.py
+++ b/processor/generator.py
@@ -330,7 +330,7 @@ class Generator(abc.ABC):
             #     self._volume_unshifted_min = min(
             #         self._volume_unshifted_min, np.min(self._volume)
             #     )
-            self._volume_unshifted_min = np.min(self._volume[-25 * 50 :])
+            self._volume_unshifted_min = np.min(self._volume[-15 * 50 :])
             #
             # END
 


### PR DESCRIPTION
Fixes #55 by limiting to 15 seconds, and adding a 5 stage fadeout (3 s per color). Limits are now initially fixed (but still adjustable by hand).

Fixes #57 by only considering the first 15 seconds for the minimums (much nicer in main screen, too). The range has been extended slightly (32 seconds), and the drilldown clips to exactly 30 seconds, smoothly trimming over time. Makes the overwrite mode look nicer, too. Same technique applied to the main page to possibly improve performance slightly.

Fixes #56 by adjusting just the drilldown plots to plot L and change automatically. We control the main page limits, so leaving that in mL.