### PR TITLE
Define the moment of 'empty breath' when the flow is crossing -0.5 'nonzero threshold', rather than the closest point of exactly zero.

### DIFF
--- a/processor/analysis.py
+++ b/processor/analysis.py
@@ -140,8 +140,8 @@ def find_roots(
         & (0.5 * (values[:-1] + values[1:]) >= values_threshold)
     )
     (C,) = np.nonzero(
-        (values[:-1] >= 0)
-        & (values[1:] < 0)
+        (values[:-1] >= -0.5*values_threshold)
+        & (values[1:] < -0.5*values_threshold)
         & (0.5 * (derivative[:-1] + derivative[1:]) < -derivative_threshold)
     )
     (D,) = np.nonzero(

--- a/processor/analysis.py
+++ b/processor/analysis.py
@@ -140,8 +140,8 @@ def find_roots(
         & (0.5 * (values[:-1] + values[1:]) >= values_threshold)
     )
     (C,) = np.nonzero(
-        (values[:-1] >= -0.5*values_threshold)
-        & (values[1:] < -0.5*values_threshold)
+        (values[:-1] >= -0.5 * values_threshold)
+        & (values[1:] < -0.5 * values_threshold)
         & (0.5 * (derivative[:-1] + derivative[1:]) < -derivative_threshold)
     )
     (D,) = np.nonzero(


### PR DESCRIPTION
This is motivated by the desire to keep the I:E ratio stable. The QuickLung has "empty" periods of very nearly zero flow, so the point that our turning-point calculation identifies as "zero flow" (green lines) can be anywhere in that flat plateau.

![quicklungRp5_breaths](https://user-images.githubusercontent.com/1852447/88982498-0c31ca00-d28e-11ea-9e5d-be36b522388a.png)

By defining the "empty" time as the point when flow goes through ‒0.5 `values_threshold` (the minimum value that is considered "nonzero"), we can get the "empty" points to be consistently at the late end of the plateau, just before the flow goes negative before another breath.

![quicklungRp5_breaths_after](https://user-images.githubusercontent.com/1852447/88982591-50bd6580-d28e-11ea-96bb-53e295bacc3d.png)

(Note that all but one of the empty time points (green lines) has moved to the end of its plateau. There are still a few outliers, but _most_ of the empty time points have moved to the ends of their plateaus.)

The effect this has on I:E is that we're no longer vacillating between the inhale getting most of the time and the exhale getting most of the time. This is what the values looked like before the correction:

![ie-ratio-before](https://user-images.githubusercontent.com/1852447/88982646-79455f80-d28e-11ea-9c6f-b5e8235ea343.png)

and this is what it looks like now:

![ie-ratio-after](https://user-images.githubusercontent.com/1852447/88982657-7f3b4080-d28e-11ea-9db2-72fab7cb82dd.png)

Picking a nonzero threshold like this raises a possibility that two turning points get out of order, which is corrected in the next stage of processing, but by taking midpoints between good turning points. Thus, we have a few "catastrophic" errors after the correction, in which the I:E ratio is way off, but when we're in stable conditions, the I:E is more regular—it doesn't vacillate like it used to. This is a trade-off: if we pick a threshold closer to zero, we get more regular vacillation, and if we pick a threshold closer to `values_threshold`, we get more catastrophic errors. Picking a point right in the middle balances between them. (And an _O(1)_ fraction is natural, since `values_threshold` is what determines "value is nonzero" for root-finding in the derivatives: the "mid-inhale" and "mid-exhale" turning points.)

I haven't been able to find a simpler or more effective method of stabilizing I:E.